### PR TITLE
Use single quotes to prevent early escaping

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -151,15 +151,15 @@ module MarkdownLint
         raise "list_style called with non-list element"
       end
       line = element_line(item).strip
-      if line.start_with?("*")
+      if line.start_with?('*')
         :asterisk
-      elsif line.start_with?("+")
+      elsif line.start_with?('+')
         :plus
-      elsif line.start_with?("-")
+      elsif line.start_with?('-')
         :dash
-      elsif line.match("[0-9]+\.")
+      elsif line.match('[0-9]+\.')
         :ordered
-      elsif line.match("[0-9]+\)")
+      elsif line.match('[0-9]+\)')
         :ordered_paren
       else
         :unknown


### PR DESCRIPTION
Before this commit, the use of double quotes and an escaped paren
and slash were being passed to the regex parsing engine as unescaped
characters, due to the double quotes handling the escaping.

Using single quotes, the escape is not handled in the string,
instead the regex engine sees the escaped characters and treats
them as literals, rather than part of the regex.
