### PR TITLE
setext_with_atx shouldn’t generate warnings when ATX only headers are used

### DIFF
--- a/test/rule_tests/headers_good_2_setext_with_atx.md
+++ b/test/rule_tests/headers_good_2_setext_with_atx.md
@@ -1,0 +1,5 @@
+# Header 1
+
+## Header 2
+
+### Header 3

--- a/test/rule_tests/headers_good_2_setext_with_atx_style.rb
+++ b/test/rule_tests/headers_good_2_setext_with_atx_style.rb
@@ -1,0 +1,2 @@
+all
+rule 'MD003', :style => :setext_with_atx


### PR DESCRIPTION
Rule `MD003` for headers should accept ATX only headers as well when `setext_with_atx` value is given to `style` option.

With this commit I added a test case that proves a fix is necessary.

@mivok this PR doesn’t contain the fix however. I :pray: you will still appreciate and add fixing commits. :beers: 
