### PR TITLE
Probe for .mdlrc

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,8 @@
 # Mdl configuration
 
 Markdownlint has several options you can configure both on the command line,
-or in markdownlint's configuration file: `.mdlrc` in your home directory.
+or in markdownlint's configuration file: `.mdlrc`, first looked for from the
+working directory, then in your home directory.
 While markdownlint will work perfectly well out of the box, this page
 documents some of the options you can change to suit your needs.
 


### PR DESCRIPTION
Look up directories for `.mdlrc` before falling back to home. This
allows per project `.mdlrc`. The `-c` flag can be passed an alternate
filename to look for, unless it is a (relative or absolute) path, in
which case no probing will be performed and the path will be used as is.

Fixes #103, #51.
