### PR TITLE
MD013: allow excluding code blocks and tables

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -266,7 +266,7 @@ lines inside code blocks.
 
 Tags: line_length
 
-Parameters: line_length (number; default 80)
+Parameters: line_length, code_blocks (number; default 80, boolean; default true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line
@@ -275,6 +275,10 @@ up into multiple lines.
 This rule has an exception where there is no whitespace beyond the configured
 line length. This allows you to still include items such as long URLs without
 being forced to break them in the middle.
+
+Code blocks are included by default since it is often a requirement for
+document readability, and tentatively compatible with code rules. Still, some
+languages do not lend themselves to short lines.
 
 ## MD014 - Dollar signs used before commands without showing output
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -266,7 +266,7 @@ lines inside code blocks.
 
 Tags: line_length
 
-Parameters: line_length, code_blocks (number; default 80, boolean; default true)
+Parameters: line_length, code_blocks, tables (number; default 80, boolean; default true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -163,9 +163,15 @@ end
 
 rule "MD013", "Line length" do
   tags :line_length
-  params :line_length => 80
+  params :line_length => 80, :code_blocks => true
   check do |doc|
-    doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
+    # Every line in the document that is part of a code block.
+    codeblock_lines = doc.find_type_elements(:codeblock).map{
+      |e| (doc.element_linenumber(e)..
+           doc.element_linenumber(e) + e.value.count('\n') - 1).to_a }.flatten
+    overlines = doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
+    overlines -= codeblock_lines unless params[:code_blocks]
+    overlines
   end
 end
 

--- a/test/rule_tests/long_lines_code.md
+++ b/test/rule_tests/long_lines_code.md
@@ -8,3 +8,31 @@ This is a short line.
 Here is a short line in a code block.
 Here is a very very very very very very very very very very very very very very very very very very very long line in a code block.
 ```
+
+This is a short line.
+
+| First Header  | Second Header | Third Header  | Fourth Header | Fifth Header  | Sixth  Header |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  |
+| ============= | ============= | ============= | ============= | ============= | ============= |
+| Footer Cell   | Footer Cell   | Footer Cell   | Footer Cell   | Footer Cell   | Footer Cell   |
+{: rules="groups"}
+
+This is a very very very very very very very very very very very very very very very very very very very very long line. {MD013}
+
+Another line.
+
+| First Header  | Second Header | Third Header  | Fourth Header | Fifth Header  | Sixth  Header |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  | Content Cell  |
+| ============= | ============= | ============= | ============= | ============= | ============= |
+| Footer Cell   | Footer Cell   | Footer Cell   | Footer Cell   | Footer Cell   | Footer Cell   |
+{: rules="groups"}

--- a/test/rule_tests/long_lines_code.md
+++ b/test/rule_tests/long_lines_code.md
@@ -1,0 +1,10 @@
+This is a short line.
+
+This is a very very very very very very very very very very very very very very very very very very very very long line. {MD013}
+
+This is a short line.
+
+```text
+Here is a short line in a code block.
+Here is a very very very very very very very very very very very very very very very very very very very long line in a code block.
+```

--- a/test/rule_tests/long_lines_code_style.rb
+++ b/test/rule_tests/long_lines_code_style.rb
@@ -1,0 +1,3 @@
+all
+rule 'MD013', :code_blocks => false
+exclude_rule "MD041"

--- a/test/rule_tests/long_lines_code_style.rb
+++ b/test/rule_tests/long_lines_code_style.rb
@@ -1,3 +1,3 @@
 all
-rule 'MD013', :code_blocks => false
+rule 'MD013', :code_blocks => false, :tables => false
 exclude_rule "MD041"


### PR DESCRIPTION
It is not sensible in some scenarios and languages to force code blocks
to 80 lines, especially since they're not subject to reflow.
