### PR TITLE
Support .markdown file extension

### DIFF
--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -59,10 +59,10 @@ module MarkdownLint
       if Dir.exist?(filename)
         if Config[:git_recurse]
           Dir.chdir(filename) do
-            cli.cli_arguments[i] = %x(git ls-files '*.md').split("\n")
+            cli.cli_arguments[i] = %x(git ls-files '*.md' '*.markdown').split("\n")
           end
         else
-          cli.cli_arguments[i] = Dir["#{filename}/**/*.md"]
+          cli.cli_arguments[i] = Dir["#{filename}/**/*.{md,markdown}"]
         end
       end
     end

--- a/test/fixtures/dir_with_md_and_markdown/bar.markdown
+++ b/test/fixtures/dir_with_md_and_markdown/bar.markdown
@@ -1,0 +1,1 @@
+## Second Header First

--- a/test/fixtures/dir_with_md_and_markdown/foo.md
+++ b/test/fixtures/dir_with_md_and_markdown/foo.md
@@ -1,0 +1,1 @@
+## Second Header First

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -195,4 +195,11 @@ class TestCli < Minitest::Test
     assert_rules_disabled(result, ["MD001"])
     assert_rules_enabled(result, ["MD002"])
   end
+
+  def test_directory_scanning
+    path = File.expand_path("./fixtures/dir_with_md_and_markdown", File.dirname(__FILE__))
+    result = run_cli("#{path}")
+    files_with_issues = result[:stdout].split("\n").map { |l| l.split(":")[0] }.sort
+    assert_equal(files_with_issues, ["#{path}/bar.markdown", "#{path}/foo.md"])
+  end
 end


### PR DESCRIPTION
Though less common than *.md, *.markdown is still fairly common: it's
the extension suggested by [Markdown's creator](http://daringfireball.net/linked/2014/01/08/markdown-extension), and is also
supported by GitHub.
