### PR TITLE
Fix uninitialized constant MarkdownLint::CLI::Pathname at launch

### DIFF
--- a/lib/mdl/cli.rb
+++ b/lib/mdl/cli.rb
@@ -1,4 +1,5 @@
 require 'mixlib/cli'
+require 'pathname'
 
 module MarkdownLint
   class CLI


### PR DESCRIPTION
Running `mdl <file>` fails with:

```
/usr/local/lib/ruby/gems/2.3.0/gems/mdl-0.3.0/lib/mdl/cli.rb:155:in `probe_config_file': uninitialized constant MarkdownLint::CLI::Pathname (NameError)
    from /usr/local/lib/ruby/gems/2.3.0/gems/mdl-0.3.0/lib/mdl/cli.rb:98:in `run'
    from /usr/local/lib/ruby/gems/2.3.0/gems/mdl-0.3.0/lib/mdl.rb:14:in `run'
    from /usr/local/lib/ruby/gems/2.3.0/gems/mdl-0.3.0/bin/mdl:10:in `<top (required)>'
    from /usr/local/bin/mdl:23:in `load'
    from /usr/local/bin/mdl:23:in `<main>'
```

It comes from a missing import.
