### PR TITLE
Update MD002, MD025, and MD041 to be configurable

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -35,11 +35,13 @@ level at a time:
     ### Another Header 3
 
 
-## MD002 - First header should be a h1 header
+## MD002 - First header should be a top level header
 
 Tags: headers
 
 Aliases: first-header-h1
+
+Parameters: level (number; default 1)
 
 This rule is triggered when the first header in the document isn't a h1 header:
 
@@ -506,6 +508,8 @@ Tags: headers
 
 Aliases: single-h1
 
+Parameters: level (number; default 1)
+
 This rule is triggered when a top level header is in use (the first line of
 the file is a h1 header), and more than one h1 header is in use in the
 document:
@@ -528,6 +532,9 @@ Rationale: A top level header is a h1 on the first line of the file, and
 serves as the title for the document. If this convention is in use, then there
 can not be more than one title for the document, and the entire document
 should be contained within this header.
+
+Note: The `level` parameter can be used to change the top level (ex: to h2) in
+cases where an h1 is added externally.
 
 ## MD026 - Trailing punctuation in header
 
@@ -968,6 +975,8 @@ Tags: headers
 
 Aliases: first-line-h1
 
+Parameters: level (number; default 1)
+
 This rule is triggered when the first line in the file isn't a top level (h1)
 header:
 
@@ -982,3 +991,6 @@ To fix this, add a header to the top of your file:
 
     This is a file with a top level header
     ```
+
+Note: The `level` parameter can be used to change the top level (ex: to h2) in
+cases where an h1 is added externally.

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -15,12 +15,13 @@ rule "MD001", "Header levels should only increment by one level at a time" do
   end
 end
 
-rule "MD002", "First header should be a h1 header" do
+rule "MD002", "First header should be a top level header" do
   tags :headers
   aliases 'first-header-h1'
+  params :level => 1
   check do |doc|
     first_header = doc.find_type(:header).first
-    [first_header[:location]] if first_header and first_header[:level] != 1
+    [first_header[:location]] if first_header and first_header[:level] != @params[:level]
   end
 end
 
@@ -342,8 +343,9 @@ end
 rule "MD025", "Multiple top level headers in the same document" do
   tags :headers
   aliases 'single-h1'
+  params :level => 1
   check do |doc|
-    headers = doc.find_type(:header).select { |h| h[:level] == 1 }
+    headers = doc.find_type(:header).select { |h| h[:level] == params[:level] }
     if not headers.empty? and doc.element_linenumber(headers[0]) == 1
       headers[1..-1].map { |h| doc.element_linenumber(h) }
     end
@@ -599,9 +601,10 @@ end
 rule "MD041", "First line in file should be a top level header" do
   tags :headers
   aliases 'first-line-h1'
+  params :level => 1
   check do |doc|
     first_header = doc.find_type(:header).first
     [1] if first_header.nil? or first_header[:location] != 1 \
-      or first_header[:level] != 1
+      or first_header[:level] != params[:level]
   end
 end

--- a/test/rule_tests/alternate_top_level_header.md
+++ b/test/rule_tests/alternate_top_level_header.md
@@ -1,0 +1,3 @@
+## A level 2 top level header
+
+## Another one {MD025}

--- a/test/rule_tests/alternate_top_level_header_style.rb
+++ b/test/rule_tests/alternate_top_level_header_style.rb
@@ -1,0 +1,4 @@
+all
+rule 'MD002', :level => 2
+rule 'MD025', :level => 2
+rule 'MD041', :level => 2


### PR DESCRIPTION
I usually have the `h1` generated by a template engine (like jekyll). I still want to be able to check that the first header is an `h2`, so I made the first header rules configurable to allow for a different first header level.

It defaults to 1 so this would be a nonbreaking change to projects already using the previous implementation.
