### PR TITLE
added support for ignore_front_matter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,16 @@ instead, and ignore any files git doesn't know about.
 * Config file: `git_recurse true`
 * Default: false
 
+Ignore YAML front matter - if this option is enabled markdownlint will ignore
+content within valid
+[YAML front matter](https://jekyllrb.com/docs/frontmatter/). Reported line
+numbers will still match the file contents but markdownlint will consider the
+line following front matter to be the first line.
+
+* Command line: `-i`, `--ignore-front-matter`
+* Config file: `ignore-front-matter true`
+* Default: false
+
 ### Specifying which rules mdl processes
 
 Tags - Limit the rules mdl enables to those containing the provided tags.

--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -71,7 +71,9 @@ module MarkdownLint
     status = 0
     cli.cli_arguments.each do |filename|
       puts "Checking #{filename}..." if Config[:verbose]
-      doc = Doc.new_from_file(filename)
+      ignore_front_matter = (Config[:ignore_front_matter] == true)? true: false;
+      doc = Doc.new_from_file(filename, ignore_front_matter)
+      line_offset = doc.offset
       filename = '(stdin)' if filename == "-"
       if Config[:show_kramdown_warnings]
         status = 2 if not doc.parsed.warnings.empty?
@@ -85,6 +87,7 @@ module MarkdownLint
         next if error_lines.nil? or error_lines.empty?
         status = 1
         error_lines.each do |line|
+          line += line_offset
           if Config[:show_aliases]
             puts "#{filename}:#{line}: #{rule.aliases.first || id} #{rule.description}"
           else

--- a/lib/mdl/cli.rb
+++ b/lib/mdl/cli.rb
@@ -27,6 +27,12 @@ module MarkdownLint
       :description => 'Increase verbosity',
       :boolean => true
 
+    option :ignore_front_matter,
+      :short => '-i',
+      :long => '--ignore-front-matter',
+      :boolean => true,
+      :description => 'Ignore YAML front matter'
+
     option :show_kramdown_warnings,
       :short => '-w',
       :long => '--[no-]warnings',

--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -27,7 +27,14 @@ module MarkdownLint
     ##
     # Create a new document given a string containing the markdown source
 
-    def initialize(text)
+    def initialize(text, ignore_front_matter = false)
+      regex = /^---([\s\S]+?)---\n/
+      if ignore_front_matter and regex.match(text)
+        @offset = regex.match(text).to_s.split("\n").length
+        text.sub!(regex,'')
+      else
+        @offset = 0
+      end
       @lines = text.split("\n")
       @parsed = Kramdown::Document.new(text, :input => 'MarkdownLint')
       @elements = @parsed.root.children
@@ -37,12 +44,20 @@ module MarkdownLint
     ##
     # Alternate 'constructor' passing in a filename
 
-    def self.new_from_file(filename)
+    def self.new_from_file(filename, ignore_front_matter = false)
       if filename == "-"
-        self.new(STDIN.read)
+        self.new(STDIN.read, ignore_front_matter)
       else
-        self.new(File.read(filename))
+        self.new(File.read(filename), ignore_front_matter)
       end
+    end
+
+    ##
+    # Returns the line number offset which is greater than zero when the
+    # markdown file contains YAML front matter that should be ignored.
+
+    def offset
+      @offset
     end
 
     ##

--- a/test/fixtures/front_matter/jekyll_post.md
+++ b/test/fixtures/front_matter/jekyll_post.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title: Hello World!
+category: Meta
+tags:
+- tag
+- another tag
+- one more tag
+url: http://example.com
+excerpt: Hello World! Vestibulum imperdiet adipiscing arcu, quis aliquam dolor condimentum dapibus. Aliquam fermentum leo aliquet quam volutpat et molestie mauris mattis. Suspendisse semper consequat velit in suscipit.
+---
+# header1
+
+This is just a sample post.
+
+### offending header3

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -231,4 +231,10 @@ class TestCli < Minitest::Test
     files_with_issues = result[:stdout].split("\n").map { |l| l.split(":")[0] }.sort
     assert_equal(files_with_issues, ["#{path}/bar.markdown", "#{path}/foo.md"])
   end
+
+  def test_ignore_front_matter
+    path = File.expand_path("./fixtures/front_matter", File.dirname(__FILE__))
+    result = run_cli_with_rc_flag("-i -r MD001,MD041,MD034 #{path}")
+    assert_equal(result[:stdout], "#{path}/jekyll_post.md:16: MD001 Header levels should only increment by one level at a time\n")
+  end
 end


### PR DESCRIPTION
I use mdl with Jekyll posts, but most have issues with content in the YAML front matter. This pull request would make it possible to ignore the front matter, but markdownlint would report errors with the correct line numbers even thought it would consider the first line to be line following the front matter.

I do think my code could use some clean up and am looking for some mentoring on this issue.

This pull request would close https://github.com/mivok/markdownlint/issues/130
