### PR TITLE
Bumped alpine version in the Dockerfile to fix build

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,9 +1,8 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 MAINTAINER Mark Harrison <mark@mivok.net>
 
-RUN apk update && \
-    apk add --no-cache ruby && \
+RUN apk add --no-cache ruby && \
     gem install --no-rdoc --no-ri mdl && \
     mkdir /data
 


### PR DESCRIPTION
With the original version I was getting the following error:

`ERROR:  Could not find a valid gem 'mdl' (>= 0), here is why:
Unable to download data from https://rubygems.org/ - SSL_connect returned=1 errno=0 state=error: certificate verify failed (https://api.rubygems.org/specs.4.8.gz)`

Bumping Alpine to latest version fixed it.
Also removed an unnecessary apk update.