### PR TITLE
Add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: markdownlint
+  name: Markdownlint
+  description: Run markdownlint on your Markdown files
+  entry: mdl
+  language: ruby
+  files: \.(md|mdown|markdown)$


### PR DESCRIPTION
Consider adding a `.pre-commit-hooks.yaml` file so markdownlint can be used with [`pre-commit`](http://pre-commit.com/).