### PR TITLE
Typo in RULES.md

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -991,9 +991,9 @@ header:
 
 To fix this, add a header to the top of your file:
 
-    ```
     # File with header
 
+    ```
     This is a file with a top level header
     ```
 


### PR DESCRIPTION
In MD041, the correct example wasn't correct.