### PR TITLE
Allow "changelog-style" header organization

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -485,7 +485,7 @@ Tags: headers
 
 Aliases: no-duplicate-header
 
-Parameters: allow_different_nesting (boolean; default true)
+Parameters: allow_different_nesting (boolean; default false)
 
 This rule is triggered if there are multiple headers in the document that have
 the same text:

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -485,6 +485,8 @@ Tags: headers
 
 Aliases: no-duplicate-header
 
+Parameters: allow_different_nesting (boolean; default true)
+
 This rule is triggered if there are multiple headers in the document that have
 the same text:
 
@@ -501,6 +503,21 @@ To fix this, ensure that the content of each header is different:
 Rationale: Some markdown parses generate anchors for headers based on the
 header name, and having headers with the same content can cause problems with
 this.
+
+If the parameter `allow_different_nesting` is set to `true`, header duplication
+under different nesting is allowed, like it usually happens in change logs:
+
+    # Change log
+
+    ## 2.0.0
+
+    ### Bug fixes
+
+    ### Features
+
+    ## 1.0.0
+
+    ### Bug fixes
 
 ## MD025 - Multiple top level headers in the same document
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -332,7 +332,7 @@ end
 rule "MD024", "Multiple headers with the same content" do
   tags :headers
   aliases 'no-duplicate-header'
-  params :allow_different_nesting => true
+  params :allow_different_nesting => false
   check do |doc|
     headers = doc.find_type(:header)
     allow_different_nesting = params[:allow_different_nesting]

--- a/test/rule_tests/header_duplicate_content_different_nesting.md
+++ b/test/rule_tests/header_duplicate_content_different_nesting.md
@@ -1,0 +1,11 @@
+# Change log
+
+## 2.0.0
+
+### Bug fixes
+
+### Features
+
+## 1.0.0
+
+### Bug fixes

--- a/test/rule_tests/header_duplicate_content_different_nesting_style.rb
+++ b/test/rule_tests/header_duplicate_content_different_nesting_style.rb
@@ -1,0 +1,1 @@
+rule "MD024", :allow_different_nesting => true

--- a/test/rule_tests/header_duplicate_content_no_different_nesting.md
+++ b/test/rule_tests/header_duplicate_content_no_different_nesting.md
@@ -1,0 +1,13 @@
+# Change log
+
+## 2.0.0
+
+### Bug fixes
+
+### Features
+
+## 1.0.0
+
+### Bug fixes
+
+{MD024:11}

--- a/test/rule_tests/header_duplicate_content_no_different_nesting_style.rb
+++ b/test/rule_tests/header_duplicate_content_no_different_nesting_style.rb
@@ -1,1 +1,0 @@
-rule "MD024", :allow_different_nesting => false

--- a/test/rule_tests/header_duplicate_content_no_different_nesting_style.rb
+++ b/test/rule_tests/header_duplicate_content_no_different_nesting_style.rb
@@ -1,0 +1,1 @@
+rule "MD024", :allow_different_nesting => false


### PR DESCRIPTION
Fixes #175.

I chose to add this as a style (although I made it the default, not sure about that), because the original check can still be useful for some people.

Can styles be configured on a per-file basis, by the way?