### PR TITLE
Fixes rule MD036-related error (NoMethodError)

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -585,6 +585,7 @@ rule "MD036", "Emphasis used instead of a header" do
       next unless [:em, :strong].include?(p.children[0].type)
       lines = doc.extract_text(p.children[0], "", false)
       next if lines.length > 1
+      next if lines.empty?
       next if lines[0].match(/[#{params[:punctuation]}]$/)
       errors << doc.element_linenumber(p)
     end

--- a/test/rule_tests/emphasis_instead_of_headers.md
+++ b/test/rule_tests/emphasis_instead_of_headers.md
@@ -38,3 +38,5 @@ not trigger the rule.
 detected as a header because it's on multiple lines**
 
 **This also shouldn't be detected as a header as it ends in punctuation.**
+
+**[This as well since it is a link](https://example.com)**


### PR DESCRIPTION
This would allow lines like the following without crashing `mdl`:

```
**[I am a link](https://example.com)**
```

Fixes #211