### PR TITLE
Avoid MD039-related (NoMethodError) crash

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -621,6 +621,7 @@ rule "MD039", "Spaces inside link text" do
   check do |doc|
     doc.element_linenumbers(
       doc.find_type_elements(:a).select{|e|
+      next if e.children.empty?
       e.children.first.type == :text && e.children.last.type == :text and (
         e.children.first.value.start_with?(" ") or
         e.children.last.value.end_with?(" "))}


### PR DESCRIPTION
This would allow lines like the following without crashing `mdl`:

```
[](https://example.com)
```

NOTE: I think another rule should check for empty [link] brackets.

Resolves #226