### PR TITLE
change newline delimiter from "\n" to /\R/

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -41,7 +41,7 @@ module MarkdownLint
       else
         @offset = 0
       end
-      @lines = text.split("\n")
+      @lines = text.split(/\R/)
       @parsed = Kramdown::Document.new(text, :input => 'MarkdownLint')
       @elements = @parsed.root.children
       add_levels(@elements)


### PR DESCRIPTION
Fix of https://github.com/markdownlint/markdownlint/issues/237