### PR TITLE
Fix for Kramdown tables of contents

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -516,6 +516,7 @@ rule "MD032", "Lists should be surrounded by blank lines" do
     fence = nil
     prev_line = ""
     doc.lines.each_with_index do |line, linenum|
+      next if line.strip == '{:toc}'
       if not in_code
         list_marker = line.strip.match(/^([\*\+\-]|(\d+\.))\s/)
         if list_marker and not in_list and not prev_line.match(/^($|\s)/)


### PR DESCRIPTION
A Kramdown auto table of contents requires a list item to be followed on
the next line by a reference {:toc}.

This fixes rule MD032 to allow the auto-toc.

A more general fix to allow other Kramdown tags would still be required.