### PR TITLE
Use "MY" prefix for custom rule example

### DIFF
--- a/docs/creating_rules.md
+++ b/docs/creating_rules.md
@@ -3,7 +3,7 @@
 Rules are written in ruby, using a rule DSL for defining rules. A rule looks
 like:
 
-    rule "MD000", "Rule description" do
+    rule "MY000", "Rule description" do
       tags :foo, :bar
       aliases 'rule-name'
       params :style => :foo


### PR DESCRIPTION
The example custom rule uses the identifier "`MD000`", with prefix "`MD`". Shouldn't custom rules use a different prefix, to avoid colliding with the built-in "`MD*`" rules?