### PR TITLE
Nicer error message when activating nonexistent rule

### DIFF
--- a/lib/mdl/style.rb
+++ b/lib/mdl/style.rb
@@ -29,7 +29,7 @@ module MarkdownLint
         raise "'rule' does not take a block. Should this definition go in a ruleset instead?"
       end
       id = @aliases[id] if @aliases[id]
-      if @all_rules[id].nil?
+      unless @all_rules[id]
         raise "No such rule: #{id}"
       end
       @rules << id

--- a/lib/mdl/style.rb
+++ b/lib/mdl/style.rb
@@ -25,7 +25,13 @@ module MarkdownLint
     end
 
     def rule(id, params={})
+      if block_given?
+        raise "'rule' does not take a block. Should this definition go in a ruleset instead?"
+      end
       id = @aliases[id] if @aliases[id]
+      if @all_rules[id].nil?
+        raise "No such rule: #{id}"
+      end
       @rules << id
       @all_rules[id].params(params)
     end


### PR DESCRIPTION
Currently, if I try to activate a non-existent rule in a style file, I get a hard-to-read stack trace error.

```ruby
rule 'bogus-rule'
```

```
$ mdl _pages --style _linter/markdown-linter-style.rb                              ✘ 127 master ✱
Traceback (most recent call last):
	7: from /Users/janke/bin-local/mdl:23:in `<main>'
	6: from /Users/janke/bin-local/mdl:23:in `load'
	5: from /usr/local/lib/ruby/gems/2.5.0/gems/mdl-0.5.0/bin/mdl:10:in `<top (required)>'
	4: from /usr/local/lib/ruby/gems/2.5.0/gems/mdl-0.5.0/lib/mdl.rb:26:in `run'
	3: from /usr/local/lib/ruby/gems/2.5.0/gems/mdl-0.5.0/lib/mdl/style.rb:51:in `load'
	2: from /usr/local/lib/ruby/gems/2.5.0/gems/mdl-0.5.0/lib/mdl/style.rb:51:in `instance_eval'
	1: from _linter/markdown-linter-style.rb:4:in `load'
/usr/local/lib/ruby/gems/2.5.0/gems/mdl-0.5.0/lib/mdl/style.rb:30:in `rule': undefined method `params' for nil:NilClass (NoMethodError)
```

This PR adds an input check to produce a nicer error message when referencing a non-existent rule.

It also checks to see if `rule` was passed a block, which probably means that someone called the style `rule` DSL, when they meant to call the ruleset `style` DSL.

Would help with https://github.com/markdownlint/markdownlint/issues/244.