### PR TITLE
Fix config file option in configuration documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ numbers will still match the file contents but markdownlint will consider the
 line following front matter to be the first line.
 
 * Command line: `-i`, `--ignore-front-matter`
-* Config file: `ignore-front-matter true`
+* Config file: `ignore_front_matter true`
 * Default: false
 
 ### Specifying which rules mdl processes


### PR DESCRIPTION
The version of the "ignore front matter" option used in the config files uses underscores, not hyphens. Using hyphens throws a parse error.

```
Traceback (most recent call last):
        6: from /usr/local/bin/mdl:23:in `<main>'
        5: from /usr/local/bin/mdl:23:in `load'
        4: from /usr/local/lib/ruby/gems/2.6.0/gems/mdl-0.5.0/bin/mdl:10:in `<top (required)>'
        3: from /usr/local/lib/ruby/gems/2.6.0/gems/mdl-0.5.0/lib/mdl.rb:15:in `run'
        2: from /usr/local/lib/ruby/gems/2.6.0/gems/mdl-0.5.0/lib/mdl/cli.rb:119:in `run'
        1: from /usr/local/lib/ruby/gems/2.6.0/gems/mixlib-config-2.2.18/lib/mixlib/config.rb:63:in `from_file'
/usr/local/lib/ruby/gems/2.6.0/gems/mixlib-config-2.2.18/lib/mixlib/config.rb:63:in `instance_eval': <... path ...>/.mdlrc:2: syntax error, unexpected true, expecting do or '{' or '(' (SyntaxError)
ignore-front-matter true
                    ^~~~
```