### PR TITLE
CI: extend and update matrix, add JRuby, allow Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 dist: trusty
 language: ruby
 
@@ -15,9 +14,10 @@ notifications:
 
 matrix:
   include:
-    - rvm: 2.3.4
-    - rvm: 2.4.1
-    - rvm: 2.5.1
-#    - rvm: jruby-9.1.9.0
-#      env: JRUBY_OPTS="--dev"
-#    - rvm: jruby-9.2.0.0
+    - rvm: 2.3.8
+    - rvm: 2.4.5
+    - rvm: 2.5.3
+    - rvm: 2.6.1
+    - rvm: jruby-9.1.17.0
+      env: JRUBY_OPTS="--dev"
+    - rvm: jruby-9.2.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,4 @@ matrix:
     - rvm: 2.4.6
     - rvm: 2.5.5
     - rvm: 2.6.2
-    - rvm: jruby-9.1.17.0
-      env: JRUBY_OPTS="--dev"
     - rvm: jruby-9.2.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
   include:
     - rvm: 2.3.8
     - rvm: 2.4.6
-    - rvm: 2.5.3
-    - rvm: 2.6.1
+    - rvm: 2.5.5
+    - rvm: 2.6.2
     - rvm: jruby-9.1.17.0
       env: JRUBY_OPTS="--dev"
     - rvm: jruby-9.2.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
 matrix:
   include:
     - rvm: 2.3.8
-    - rvm: 2.4.5
+    - rvm: 2.4.6
     - rvm: 2.5.3
     - rvm: 2.6.1
     - rvm: jruby-9.1.17.0

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-config', '~> 2.2', '>= 2.2.1'
   spec.add_dependency 'mixlib-cli', '~> 1.7', '>= 1.7.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler', ['>= 1.12', '< 3']
   spec.add_development_dependency 'rake', '~> 11.2'
   spec.add_development_dependency 'minitest', '~> 5.9'
   spec.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
This PR extends the CI matrix and adds back JRuby.

  - drop unused setting `sudo: false`
  - allow Bundler 2 to be used