### PR TITLE
fix(md039): fix a crash in the rule when the link text is empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ notifications:
 
 matrix:
   include:
-    - rvm: 2.3.4
-    - rvm: 2.4.1
-    - rvm: 2.5.1
+    - rvm: 2.4.6
+    - rvm: 2.5.5
+    - rvm: 2.6.2
 #    - rvm: jruby-9.1.9.0
 #      env: JRUBY_OPTS="--dev"
 #    - rvm: jruby-9.2.0.0

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -621,10 +621,10 @@ rule "MD039", "Spaces inside link text" do
   aliases 'no-space-in-links'
   check do |doc|
     doc.element_linenumbers(
-      doc.find_type_elements(:a).select{|e|
-      e.children.first.type == :text && e.children.last.type == :text and (
-        e.children.first.value.start_with?(" ") or
-        e.children.last.value.end_with?(" "))}
+      doc.find_type_elements(:a).reject{|e|e.children.empty?}.select{|e|
+        e.children.first.type == :text && e.children.last.type == :text and (
+          e.children.first.value.start_with?(" ") or
+          e.children.last.value.end_with?(" "))}
     )
   end
 end

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-config', '~> 2.2', '>= 2.2.1'
   spec.add_dependency 'mixlib-cli', '~> 1.7', '>= 1.7.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler', ['>= 1.12', '< 3']
   spec.add_development_dependency 'rake', '~> 11.2'
   spec.add_development_dependency 'minitest', '~> 5.9'
   spec.add_development_dependency 'pry', '~> 0.10'

--- a/test/rule_tests/spaces_inside_link_text.md
+++ b/test/rule_tests/spaces_inside_link_text.md
@@ -1,3 +1,5 @@
+[](http://bar/)
+
 [foo](http://bar/)
 
 ["foo"](http:/bar/)


### PR DESCRIPTION
This PR was need to fix a crash in rule MD039.

I also took the opportunity to drop support for ruby 2.3 in the CI and add ruby 2.6.