### PR TITLE
Use newer mixlib-cli

### DIFF
--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'kramdown', '~> 1.12', '>= 1.12.0'
   spec.add_dependency 'mixlib-config', '~> 2.2', '>= 2.2.1'
-  spec.add_dependency 'mixlib-cli', '~> 1.7', '>= 1.7.0'
+  spec.add_dependency 'mixlib-cli', '~> 2.1', '>= 2.1.1'
 
   spec.add_development_dependency 'bundler', ['>= 1.12', '< 3']
   spec.add_development_dependency 'rake', '~> 11.2'


### PR DESCRIPTION
I'd like to get this bundled into chefdk, so that means being on a more
modern version of mixlib-cli so we don't conflict.

I tested building the gem and basic calls, seems fine.

This will solve: https://github.com/chef/chef-workstation/pull/440