### PR TITLE
Update kramdown dependency to major ver 2

### DIFF
--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.2'
 
-  spec.add_dependency 'kramdown', '~> 1.12', '>= 1.12.0'
+  spec.add_dependency 'kramdown', '~> 2.0'
+  spec.add_dependency 'kramdown-parser-gfm', '~> 1.0'
   spec.add_dependency 'mixlib-config', '~> 2.2', '>= 2.2.1'
   spec.add_dependency 'mixlib-cli', '~> 1.7', '>= 1.7.0'
 


### PR DESCRIPTION
**Motivation:** currently `mdl` is incompatible with `forspell` gem. I have to use both of them for documentation linting.

Example of problem report:

```
➜ bundle
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "kramdown":
  In Gemfile:
    forspell (~> 0.0.8) was resolved to 0.0.8, which depends on
      kramdown (~> 2.0)

    mdl was resolved to 0.0.1, which depends on
      kramdown (>= 1.4.0, ~> 1.4)
```