### PR TITLE
Add a CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+1. Fork it ( <http://github.com/markdownlint/markdownlint/fork> )
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create new Pull Request

--- a/README.md
+++ b/README.md
@@ -85,8 +85,4 @@ For more information on creating style files, see the
 
 ## Contributing
 
-1. Fork it ( <http://github.com/markdownlint/markdownlint/fork> )
-1. Create your feature branch (`git checkout -b my-new-feature`)
-1. Commit your changes (`git commit -am 'Add some feature'`)
-1. Push to the branch (`git push origin my-new-feature`)
-1. Create new Pull Request
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.


### PR DESCRIPTION
Most users are looking for this content in a CONTRIBUTING.md file and it's encouraged by [the github community standards](https://help.github.com/en/articles/setting-guidelines-for-repository-contributors), so let's comply.

We should probably add more content and guidelines to this, but it's a start.