### PR TITLE
Minor typo and style fixes in doco

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Mdl configuration
 
 Markdownlint has several options you can configure both on the command line,
-or in markdownlint's configuration file: `.mdlrc`, first looked for from the
+or in markdownlint's configuration file: `.mdlrc`, first looked for in the
 working directory, then in your home directory.
 While markdownlint will work perfectly well out of the box, this page
 documents some of the options you can change to suit your needs.
@@ -39,7 +39,7 @@ instead, and ignore any files git doesn't know about.
 * Config file: `git_recurse true`
 * Default: false
 
-Ignore YAML front matter - if this option is enabled markdownlint will ignore
+Ignore YAML front matter - If this option is enabled markdownlint will ignore
 content within valid
 [YAML front matter](https://jekyllrb.com/docs/frontmatter/). Reported line
 numbers will still match the file contents but markdownlint will consider the
@@ -66,7 +66,7 @@ Rules - Limit the rules mdl enables to those provided in this option.
 If a rule or tag ID is preceded by a tilde (`~`), then it _disables_ the
 matching rules instead of enabling them, starting with all rules being enabled.
 
-Note: if both `--rules` and `--tags` are provided, then a given rule has to
+Note: If both `--rules` and `--tags` are provided, then a given rule has to
 both be in the list of enabled rules, as well as be tagged with one of the
 tags provided with the `--tags` option. Use the `-l/--list-rules` option to
 test this behavior.
@@ -81,7 +81,7 @@ might choose 72 characters, and another might have no line length limit at all
 * Config file: `style "style_name"`
 * Default: Use the style called 'default'
 
-Note: the value for `style_name` must either end with `.rb` or have `/` in it
+Note: The value for `style_name` must either end with `.rb` or have `/` in it
 in order to tell `mdl` to look for a custom style, and not a built-in style.
 
 Rulesets - Load a custom ruleset file. This option allows you to load custom

--- a/docs/creating_rules.md
+++ b/docs/creating_rules.md
@@ -46,7 +46,7 @@ for your check.
 
 ## Document objects
 
-The check takes a single parameter `'doc'`, which is an object containing a
+The check takes a single parameter `doc`, which is an object containing a
 representation of the markdown document along with several helper functions
 used for making rules. The [doc.rb](../lib/mdl/doc.rb) file is documented
 using rdoc, and you will want to take a look there to see all the methods you

--- a/docs/creating_styles.md
+++ b/docs/creating_styles.md
@@ -6,28 +6,28 @@ parameters different than the defaults.
 
 The various options you can use in a style file are:
 
-* all - include all rules
-* rule - include a specific rule.
+* `all` - include all rules
+* `rule` - include a specific rule.
 
         rule 'MD001'
 
-* exclude_rule - exclude a previously included rule. Used if you want to
+* `exclude_rule` - exclude a previously included rule. Used if you want to
   include all except for a few rules.
 
         exclude_rule 'MD000'
 
-* tag - include all rules that are tagged with a specific value
+* `tag` - include all rules that are tagged with a specific value
 
         tag :whitespace
 
-* exclude_tag - exclude all rules tagged with the specified tag
+* `exclude_tag` - exclude all rules tagged with the specified tag
 
         exclude_tag :line_length
 
 Note that tags are specified as symbols, and rule names as strings, just as
 in the rule definitions themselves.
 
-The last matching option wins, so you should always put `'all'` at the top of
+The last matching option wins, so you should always put `all` at the top of
 the file (if you want to include all rules), then tags (and tag excludes),
 then specific rules. In other words, go from least to most specific.
 
@@ -42,6 +42,6 @@ those parameters:
 
     rule 'MD030', :ol_multi => 2, :ul_multi => 3
 
-Even if a rule is included already by a tag specification (or 'all'), it is
-not a problem to add a specific 'rule' entry in order to set custom
+Even if a rule is included already by a tag specification (or `all`), it is
+not a problem to add a specific `rule` entry in order to set custom
 parameters, and is in fact necessary to do so.

--- a/docs/rolling_a_release.md
+++ b/docs/rolling_a_release.md
@@ -4,7 +4,7 @@ Bump the version. Markdownlint uses semantic versioning. From
 <http://semver.org/>:
 
 * Major version for backwards-incompatible changes
-* Minor version functionality added in a backwards-compatible manner
+* Minor version for functionality added in a backwards-compatible manner
 * Patch version for backwards-compatible bug fixes
 * Exception: Versions < 1.0 may introduce backwards-incompatible changes in a
   minor version.


### PR DESCRIPTION
Just some suggested minor typo and style fixes in the documentation. No functional changes.