### PR TITLE
tests: Update front_matter test to check for blank-line case

### DIFF
--- a/test/fixtures/front_matter/jekyll_post_2.md
+++ b/test/fixtures/front_matter/jekyll_post_2.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: Hello World!
+category: Meta
+tags:
+- tag
+- another tag
+- one more tag
+url: http://example.com
+excerpt: Hello World! Vestibulum imperdiet adipiscing arcu, quis aliquam dolor condimentum dapibus. Aliquam fermentum leo aliquet quam volutpat et molestie mauris mattis. Suspendisse semper consequat velit in suscipit.
+---
+
+# header1
+
+This is just a sample post.
+
+### offending header3

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -194,8 +194,9 @@ class TestCli < Minitest::Test
     result = run_cli("-i -r MD001,MD041,MD034 #{path}")
 
     expected = \
-      "#{path}/jekyll_post.md:16: MD001 Header levels should only increment by one level at a time"\
-      "\n\nA detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md\n"
+      "#{path}/jekyll_post.md:16: MD001 Header levels should only increment by one level at a time\n"\
+      "#{path}/jekyll_post_2.md:16: MD001 Header levels should only increment by one level at a time\n"\
+      "\nA detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md\n"
 
     assert_equal(result[:stdout], expected)
   end


### PR DESCRIPTION
Adds a test case to cover #248's changes (where it now ignores a blank line after YAML front matter).