### PR TITLE
Add issue templates to help standardize requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -1,0 +1,22 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔.
+labels: "bug"
+---
+## Description
+<!--- Briefly describe the issue -->
+
+### Environment
+<!--- Tell us any details about the environment where you're running mdl. -->
+**MDL Version**
+<!--- Tell us which version of mdl you are using. -->
+
+### Expected Behavior
+<!-- Tell us what should happen -->
+
+### Actual Behavior
+<!-- Tell us what happens instead; including any error messages, stacktraces, or a link to a gist with it. -->
+
+## Replication Case
+<!--- Tell us what steps to take to replicate your problem, don't just say what you did, but explain how you did it. See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
+for information on how to create a good replication case -->

--- a/.github/ISSUE_TEMPLATE/DESIGN_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/DESIGN_PROPOSAL.md
@@ -1,0 +1,40 @@
+---
+name: Design Proposal
+about: I have a significant change I would like to propose and discuss before starting
+labels: "design proposal"
+---
+
+### When a Change Needs a Design Proposal
+
+A design proposal should be opened any time a change meets one of the following qualifications:
+
+- Significantly changes the user experience of a project in a way that impacts users.
+- Significantly changes the underlying architecture of the project in a way that impacts other developers.
+- Changes the development or testing process of the project such as a change of CI systems or test frameworks.
+
+### Why We Use This Process
+
+- Allows all interested parties (including any community member) to discuss large impact changes to a project.
+- Serves as a durable paper trail for discussions regarding project architecture.
+- Forces design discussions to occur before PRs are created.
+- Reduces PR refactoring and rejected PRs.
+
+---
+
+<!---  Proposal description and rationale.  -->
+
+## Motivation
+
+<!---
+    As a <<user_profile>>,
+    I want to <<functionality>>,
+    so that <<benefit>>.
+ -->
+
+## Specification
+
+<!---  A detailed description of the planned implementation. -->
+
+## Downstream Impact
+
+<!---  Which other tools will be impacted by this work?  -->

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST.md
@@ -1,0 +1,20 @@
+---
+name: 🚀 Enhancement Request
+about: I have a suggestion (and may want to implement it 🙂)!
+labels: "enhancement"
+---
+
+## Describe the Enhancement:
+<!---  What you are trying to achieve that you can't? -->
+
+### Impacted Rules:
+<!-- List any existing rules that would be impacted or changed by this enhancement -->
+
+## Describe the Need:
+<!---  What kind of user do you believe would utilize this enhancement, and how many users might want this functionality -->
+
+## Current Alternative
+<!--- Is there a current alternative that you can utilize to workaround the lack of this enhancement -->
+
+## Can We Help You Implement This?:
+<!---  The best way to ensure your enhancement is built is to help implement the enhancement yourself. If you're interested in helping out we'd love to give you a hand to make this possible. Let us know if there's something you need. -->

--- a/.github/ISSUE_TEMPLATE/RULE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/RULE_REQUEST.md
@@ -1,0 +1,20 @@
+---
+name: 💪 Rule Request
+about: I have a suggestion for a new rule for markdownlint (and may want to implement it 🙌)!
+labels: "new rule"
+---
+
+## New Rule Checklist
+
+Before suggesting a rule for inclusion please make sure your suggestion meets these criteria for rule built into markdownlint:
+ - [ ] allows a user to lint for a specific syntax divergence across the multiple flavors and styles of markdown
+ - [ ] does not dictate any one specific style, but enables an end user to enable, disable, or configure the specific style of enforcement desired
+
+## Describe The Rule:
+<!---  Tell us about the rule -->
+
+## Why Should This Be Included In Markdownlint?:
+<!---  Tell us why you believe this rule should be added, considering any possible side-effects, negative impact, or changes to the behavior of existing rules -->
+
+## Can We Help You Implement This?:
+<!---  The best way to move a rule into markdownlint is to create it yourself. If you're interested in helping out we'd love to give you a hand to make this possible. Let us know if there's something you need. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,22 @@
-# Contributing
+# Contributing to Markdownlint
+
+We're glad you want to contribute markdownlint! This document will help answer common questions you may have during your first contribution. Please, try to follow these guidelines when you do so.
+
+## Issue Reporting
+
+Not every contribution comes in the form of code. Submitting, confirming, and triaging issues is an important task for any project. We use GitHub to track all project issues. If you discover bugs, have ideas for improvements or new features, please start by [opening an issue](https://github.com/markdownlint/markdownlint/issues) on this repository. We use issues to centralize the discussion and agree on a plan of action before spending time and effort writing code that might not get used.
+
+### Submitting An Issue
+* Check that the issue has not already been reported
+* Check that the issue has not already been fixed in the latest code (a.k.a. `master`)
+* Select the appropriate issue type and open an issue with a descriptive title
+* Be clear, concise, and precise using grammatically correct, complete sentences in your summary of the problem
+* Include the output of `mdl -V` or `mdl --version`
+* Include any relevant code in the issue
+
+## Pull Requests
+
+### Contributing Process
 
 1. Fork it ( <http://github.com/markdownlint/markdownlint/fork> )
 1. Create your feature branch (`git checkout -b my-new-feature`)


### PR DESCRIPTION
Adding issue templates to standardize the information we'd like contributors to include when they open issues. I've added four different types of templates to help gather the appropriate data for the various types of issues. I've created these after reviewing the issue history for this repo as well as the issue templates configured across other active projects.

These templates will be listed as options when a user opens a new issue via the github ui, as outlined [in the github documentation](https://help.github.com/en/articles/creating-issue-templates-for-your-repository). We can create a generic template for the organization include it as another option below these primary ones for the repository, see the [chef repo issues](https://github.com/chef/chef/issues/new/choose) for an example of this functionality.