### PR TITLE
Loosen deps + set minimum version of Ruby to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
 
 matrix:
   include:
-    - rvm: 2.4.6
-    - rvm: 2.5.5
-    - rvm: 2.6.2
+    - rvm: 2.4.9
+    - rvm: 2.5.7
+    - rvm: 2.6.5
     - rvm: jruby-9.2.8.0

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -18,15 +18,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9.2'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'kramdown', '~> 2.0'
   spec.add_dependency 'kramdown-parser-gfm', '~> 1.0'
-  spec.add_dependency 'mixlib-config', '~> 2.2', '>= 2.2.1'
+  spec.add_dependency 'mixlib-config', '>= 2.2.1', '< 4'
   spec.add_dependency 'mixlib-cli', '~> 2.1', '>= 2.1.1'
 
   spec.add_development_dependency 'bundler', '>= 1.12', '< 3'
-  spec.add_development_dependency 'rake', '~> 11.2'
+  spec.add_development_dependency 'rake', '>= 11.2', '< 14'
   spec.add_development_dependency 'minitest', '~> 5.9'
   spec.add_development_dependency 'pry', '~> 0.10'
 end


### PR DESCRIPTION
The version of mixlib-cli required actually requires 2.4+ and kramdown
was 2.3+ so this would very much not work on 1.9+. I also loosened the
mixlib-config dep to allow us to bring this into workstation and upated
the Travis config to use the latest patch releases because why not.

Signed-off-by: Tim Smith <tsmith@chef.io>