### PR TITLE
Don't ship test / example files in the gem artifact

### DIFF
--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/markdownlint/markdownlint"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = %w{LICENSE.txt Gemfile} + Dir.glob("*.gemspec") + Dir.glob("lib/**/*")
+  spec.bindir        = "bin"
+  spec.executables   = %w{mdl}
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.4'


### PR DESCRIPTION
This keeps the install size down and helps out Windows systems where
malware scans of each file have to take place. This drops the gem
artifact (compressed) from 58k to 17k.

Signed-off-by: Tim Smith <tsmith@chef.io>