### PR TITLE
Consistent, but blockquoted, list items are valid

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -190,7 +190,7 @@ module MarkdownLint
       if item.type != :li
         raise "list_style called with non-list element"
       end
-      line = element_line(item).strip
+      line = element_line(item).strip.gsub(/^> /,'')
       if line.start_with?('*')
         :asterisk
       elsif line.start_with?('+')

--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -190,7 +190,7 @@ module MarkdownLint
       if item.type != :li
         raise "list_style called with non-list element"
       end
-      line = element_line(item).strip.gsub(/^> /,'')
+      line = element_line(item).strip.gsub(/^>\s+/,'')
       if line.start_with?('*')
         :asterisk
       elsif line.start_with?('+')

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -470,7 +470,7 @@ rule "MD030", "Spaces after list markers" do
       # the items in it have multiple paragraphs/other block items.
       srule = items.map { |i| i.children.length }.max > 1 ? "multi" : "single"
       items.each do |i|
-        actual_spaces = doc.element_line(i).match(/^\s*\S+(\s+)/)[1].length
+        actual_spaces = doc.element_line(i).gsub(/^> /,'').match(/^\s*\S+(\s+)/)[1].length
         required_spaces = params["#{list_type}_#{srule}".to_sym]
         errors << doc.element_linenumber(i) if required_spaces != actual_spaces
       end

--- a/test/rule_tests/blockquote_spaces.md
+++ b/test/rule_tests/blockquote_spaces.md
@@ -6,6 +6,8 @@ Some text
 
 This tests other things embedded in the blockquote:
 
+- foo
+
 > *Hello world*
 >  *foo* {MD027}
 >  **bar** {MD027}
@@ -15,6 +17,8 @@ This tests other things embedded in the blockquote:
 > **bar** more text
 > 'baz' more text
 > `qux` more text
+>
+> - foo
 
 Test the first line being indented too much:
 

--- a/test/rule_tests/inconsistent_bullet_styles_asterisk.md
+++ b/test/rule_tests/inconsistent_bullet_styles_asterisk.md
@@ -1,3 +1,7 @@
 * Item
   + Item {MD004}
   - Item {MD004}
+
+> * Item
+>   + Item {MD004}
+>   - Item {MD004}

--- a/test/rule_tests/inconsistent_bullet_styles_asterisk.md
+++ b/test/rule_tests/inconsistent_bullet_styles_asterisk.md
@@ -1,7 +1,9 @@
 * Item
   + Item {MD004}
   - Item {MD004}
+  * Item
 
 > * Item
 >   + Item {MD004}
 >   - Item {MD004}
+>   * Item

--- a/test/rule_tests/inconsistent_bullet_styles_dash.md
+++ b/test/rule_tests/inconsistent_bullet_styles_dash.md
@@ -1,7 +1,9 @@
 - Item
   * Item {MD004}
   + Item {MD004}
+  - Item
 
 > - Item
 >   * Item {MD004}
 >   + Item {MD004}
+>   - Item

--- a/test/rule_tests/inconsistent_bullet_styles_dash.md
+++ b/test/rule_tests/inconsistent_bullet_styles_dash.md
@@ -1,3 +1,7 @@
 - Item
   * Item {MD004}
   + Item {MD004}
+
+> - Item
+>   * Item {MD004}
+>   + Item {MD004}

--- a/test/rule_tests/inconsistent_bullet_styles_plus.md
+++ b/test/rule_tests/inconsistent_bullet_styles_plus.md
@@ -1,3 +1,7 @@
 + Item
   * Item {MD004}
   - Item {MD004}
+
+> + Item
+>   * Item {MD004}
+>   - Item {MD004}

--- a/test/rule_tests/inconsistent_bullet_styles_plus.md
+++ b/test/rule_tests/inconsistent_bullet_styles_plus.md
@@ -1,7 +1,9 @@
 + Item
   * Item {MD004}
   - Item {MD004}
+  + Item
 
 > + Item
 >   * Item {MD004}
 >   - Item {MD004}
+>   + Item


### PR DESCRIPTION
## Description
Adds test coverage and patches the `MarkdownLint::Doc#list_style` method to identify the style of blockquoted list items.

Adds test coverage and patches the `MD030` rule to handle blockquoted examples for `MD004`.

## Related Issues
https://github.com/markdownlint/markdownlint/issues/261

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

~- [ ] Breaking change (fix or feature that would cause existing functionality to change)~
~- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)~
~- [ ] Chore (non-breaking change that does not add functionality or fix an issue)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
