### PR TITLE
Proposal / Discussion - Junit XML Output Format

### DIFF
--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -121,7 +121,7 @@ module MarkdownLint
       output << %{<?xml version="1.0" encoding="UTF-8"?>\n}
       output << %{<testsuite}
       output << %{ name="mdl"}
-      output << %{ failures="0"}
+      output << %{ failures="#{results.count}"}
       output << %{>\n}
       results.each do |result|
         output << %{<testcase}

--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -124,15 +124,16 @@ module MarkdownLint
       output << %{ failures="#{results.count}"}
       output << %{>\n}
       results.each do |result|
+        rule_or_alias = Config[:show_aliases] ? result['aliases'].first : result['rule']
         output << %{<testcase}
-        output << %{ name="#{result['filename']}"}
+        output << %{ name="#{result['filename']}:#{result['line']}: #{rule_or_alias} #{result['description']}"}
         output << %{ file="#{result['filename']}"}
         output << %{>}
           output << %{<failure}
           output << %{ message="#{result['aliases'].first}"}
           output << %{ type="#{result['rule']}"}
           output << %{>\n}
-          output << %{#{result['filename']}:#{result['line']}: #{result['rule']} #{result['description']}\n\n}
+          output << %{#{result['filename']}:#{result['line']}: #{rule_or_alias} #{result['description']}\n\n}
           output << %{A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md\n}
           output << %{</failure>}
         output << %{</testcase>\n}

--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -95,7 +95,7 @@ module MarkdownLint
         status = 1
         error_lines.each do |line|
           line += doc.offset # Correct line numbers for any yaml front matter
-          if Config[:json]
+          if Config[:json] || Config[:junit]
             results << {
               'filename' => filename,
               'line' => line,
@@ -123,6 +123,20 @@ module MarkdownLint
       output << %{ name="mdl"}
       output << %{ failures="0"}
       output << %{>\n}
+      results.each do |result|
+        output << %{<testcase}
+        output << %{ name="#{result['filename']}"}
+        output << %{ file="#{result['filename']}"}
+        output << %{>}
+          output << %{<failure}
+          output << %{ message="#{result['aliases'].first}"}
+          output << %{ type="#{result['rule']}"}
+          output << %{>\n}
+          output << %{#{result['filename']}:#{result['line']}: #{result['rule']} #{result['description']}\n\n}
+          output << %{A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md\n}
+          output << %{</failure>}
+        output << %{</testcase>\n}
+      end
       output << %{</testsuite>\n}
       puts output
     elsif status != 0

--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -116,6 +116,15 @@ module MarkdownLint
     if Config[:json]
       require 'json'
       puts JSON.generate(results)
+    elsif Config[:junit]
+      output = ""
+      output << %{<?xml version="1.0" encoding="UTF-8"?>\n}
+      output << %{<testsuite}
+      output << %{ name="mdl"}
+      output << %{ failures="0"}
+      output << %{>\n}
+      output << %{</testsuite>\n}
+      puts output
     elsif status != 0
       puts "\nA detailed description of the rules is available at " +
            'https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md'

--- a/lib/mdl/cli.rb
+++ b/lib/mdl/cli.rb
@@ -2,7 +2,6 @@ require 'mixlib/cli'
 require 'pathname'
 
 module MarkdownLint
-  # Our Mixlib::CLI class
   class CLI
     include Mixlib::CLI
 
@@ -106,6 +105,12 @@ module MarkdownLint
            :long => '--json',
            :description => 'JSON output',
            :boolean => true
+
+    option :junit,
+      :short => '-x',
+      :long => '--xml',
+      :description => "Junit Xml output",
+      :boolean => true
 
     def run(argv = ARGV)
       parse_options(argv)

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.12', '< 3'
   spec.add_development_dependency 'minitest', '~> 5.9'
+  spec.add_development_dependency 'nokogiri', '~> 1.10.5'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '>= 11.2', '< 14'
   spec.add_development_dependency 'rubocop', '>= 0.49.0'

--- a/test/fixtures/junit_single_failure.xml
+++ b/test/fixtures/junit_single_failure.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="mdl" failures="1">
+  <testcase name="(stdin):3: MD024 Multiple headers with the same content" file="(stdin)">
+    <failure message="no-duplicate-header" type="MD024">
+      (stdin):3: MD024 Multiple headers with the same content
+
+      A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+    </failure>
+  </testcase>
+</testsuite>

--- a/test/fixtures/junit_single_pass.xml
+++ b/test/fixtures/junit_single_pass.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="mdl" failures="0">
+</testsuite>

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -17,6 +17,8 @@ class TestCli < Minitest::Test
     assert_ran_ok(result)
     expected_results = File.read(File.expand_path("../fixtures/junit_single_pass.xml", __FILE__))
     assert_equal(expected_results, result[:stdout])
+    d = Nokogiri::XML(result[:stdout])
+    assert_equal("0", d.search("[failures]").first.attributes['failures'].value)
   end
 
   def test_junit_xml_output_with_matches
@@ -25,6 +27,7 @@ class TestCli < Minitest::Test
     assert_equal("", result[:stderr])
     d = Nokogiri::XML(result[:stdout])
     refute_empty(d.search("[type=MD024]"))
+    assert_equal("1", d.search("[failures]").first.attributes['failures'].value)
   end
 
   def test_json_output

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -3,6 +3,7 @@ require 'open3'
 require 'set'
 require 'fileutils'
 require 'json'
+require 'nokogiri'
 
 class TestCli < Minitest::Test
   def test_help_text
@@ -16,6 +17,14 @@ class TestCli < Minitest::Test
     assert_ran_ok(result)
     expected_results = File.read(File.expand_path("../fixtures/junit_single_pass.xml", __FILE__))
     assert_equal(expected_results, result[:stdout])
+  end
+
+  def test_junit_xml_output_with_matches
+    result = run_cli_with_input("-x", "# header\n\n## header")
+    assert_equal(1, result[:status])
+    assert_equal("", result[:stderr])
+    d = Nokogiri::XML(result[:stdout])
+    refute_empty(d.search("[type=MD024]"))
   end
 
   def test_json_output

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -27,8 +27,20 @@ class TestCli < Minitest::Test
     assert_equal("", result[:stderr])
     d = Nokogiri::XML(result[:stdout])
     refute_empty(d.search("[type=MD024]"))
+    refute_empty(d.search("[name='(stdin):3: MD024 Multiple headers with the same content']"))
     assert_equal("1", d.search("[failures]").first.attributes['failures'].value)
   end
+
+  def test_junit_xml_output_with_matches_show_alias
+    result = run_cli_with_input("-xa", "# header\n\n## header")
+    assert_equal(1, result[:status])
+    assert_equal("", result[:stderr])
+    d = Nokogiri::XML(result[:stdout])
+    refute_empty(d.search("[type=MD024]"))
+    refute_empty(d.search("[name='(stdin):3: no-duplicate-header Multiple headers with the same content']"))
+    assert_equal("1", d.search("[failures]").first.attributes['failures'].value)
+  end
+
 
   def test_json_output
     result = run_cli_with_input('-j', "# header\n")

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -11,6 +11,13 @@ class TestCli < Minitest::Test
     assert_equal(0, result[:status])
   end
 
+  def test_junit_xml_output
+    result = run_cli_with_input("-x", "# header\n\n## header the second")
+    assert_ran_ok(result)
+    expected_results = File.read(File.expand_path("../fixtures/junit_single_pass.xml", __FILE__))
+    assert_equal(expected_results, result[:stdout])
+  end
+
   def test_json_output
     result = run_cli_with_input('-j', "# header\n")
     assert_ran_ok(result)


### PR DESCRIPTION
## Description
1. I believe this offers an MVP for Junit XML Output.
2. I am open to discussion about refactoring.
3. I am open to discussion about the preferred first Junit XML attribute mapping.

I'm sharing this now to get feedback. This change ships a barebones Junit XML output formatter. With a `-x` or `--xml` flag the `mdl` command outputs `<testcase>` tags with child `<failure>` tags listing the filename, line number and matched rule.

I have test coverage similar to what I observed for the JSON output format. To achieve that I chose to add Nokogiri as a development dependency. May be a little heavy for just a couple assertions... I could take a different approach if we don't want to depend on Nokogiri in development...

I don't know what is ideal for mapping mdl output to Junit XML attributes. I do know what I want or need out of the output format, and that is to play nicely with GitLab's junit xml output formatting/rendering.

For example, in this screenshot I'm limiting the content of the `testcase name` attribute to the filename: 

![image](https://user-images.githubusercontent.com/10550/70184122-0e5e6d00-169c-11ea-95a4-cb9afcbd9a3c.png)

and putting the detail in the text node of the single `failure` tag:

![image](https://user-images.githubusercontent.com/10550/70184431-ae1bfb00-169c-11ea-8976-3ebb8b7429bd.png)

Whereas if (for gitlab's junit output rendering widget) I put the rule match message in the `testcase name` I can save a click, but make redundant the information in the `failure` test node:

![image](https://user-images.githubusercontent.com/10550/70185003-dce6a100-169d-11ea-87db-17def0d933f0.png)

Actually, comparing the two it seems like I might benefit from grouping all the matched rules under a single `testcase` tag and seeing if gitlab does the right thing with multiple `failure` tag children.

But I digress... I'm opening this pull request to get feedback on if you want junit output formatting, and where you want that formatter implemented in the codebase, and what (if any) requirements should dictate the Junit XML implementation... I am offering as a minimum viable feature, GitLab compatible Junit XML formatting... Perhaps you have a different Junit XML consumer in mind for a minimum viable feature.

## Related Issues
#71 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
