### PR TITLE
Handle codeblocks that are nested

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -44,7 +44,7 @@ module MarkdownLint
       @lines = text.split(/\R/)
       @parsed = Kramdown::Document.new(text, :input => 'MarkdownLint')
       @elements = @parsed.root.children
-      add_levels(@elements)
+      add_annotations(@elements)
     end
 
     ##
@@ -277,12 +277,14 @@ module MarkdownLint
     private
 
     ##
-    # Adds a 'level' option to all elements to show how nested they are
+    # Adds a 'level' and 'parent' option to all elements to show how nested they
+    # are
 
-    def add_levels(elements, level=1)
+    def add_annotations(elements, level=1, parent=nil)
       elements.each do |e|
         e.options[:element_level] = level
-        add_levels(e.children, level+1)
+        e.options[:parent] = parent
+        add_annotations(e.children, level+1, e)
       end
     end
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -669,8 +669,22 @@ rule "MD046", "Code block style" do
             style = :fenced
           end
         end
-        if @params[:style] == :fenced
-          doc.element_line(i).start_with?("    ")
+        if style == :fenced
+          # if our parent is a list or a codeblock, we need to ignore
+          # its spaces, plus 4 more
+          parent = i.options[:parent]
+          ignored_spaces = 0
+          if parent
+            parent.options.delete(:children)
+            parent.options.delete(:parent)
+            if [:li, :codeblock].include?(parent.type)
+              linenum = doc.element_linenumbers([parent]).first
+              indent = doc.indent_for(doc.lines[linenum - 1])
+              ignored_spaces = indent + 4
+            end
+          end
+          start = ' ' * ignored_spaces
+          doc.element_line(i).start_with?("#{start}    ")
         else
           !doc.element_line(i).start_with?("    ")
         end

--- a/test/rule_tests/code_block_dollar.md
+++ b/test/rule_tests/code_block_dollar.md
@@ -1,33 +1,43 @@
 The following code block shouldn't have $ before the commands:
 
-    $ ls {MD014}
-    $ less foo
+```bash
+$ ls
+$ less foo
 
-    $ cat bar
+$ cat bar
+```
 
 However the following code block shows output, and $ can be used to
 distinguish between command and output:
 
-    $ ls
-    foo bar
-    $ less foo
-    Hello world
+```bash
+$ ls
+foo bar
+$ less foo
+Hello world
 
-    $ cat bar
-    baz
+$ cat bar
+baz
+```
 
 The following code block uses variable names, and likewise shouldn't fire:
 
-    $foo = 'bar';
-    $baz = 'qux';
+```bash
+$foo = 'bar';
+$baz = 'qux';
+```
 
 The following code block doesn't have any dollar signs, and shouldn't fire:
 
-    ls foo
-    cat bar
+```bash
+ls foo
+cat bar
+```
 
 The following (fenced) code block doesn't have any content at all, and
 shouldn't fire:
 
 ```bash
 ```
+
+{MD014:3}

--- a/test/rule_tests/consecutive_blank_lines.md
+++ b/test/rule_tests/consecutive_blank_lines.md
@@ -3,9 +3,11 @@ Some text
 
 Some text {MD012:3}
 
-    This is a code block
+```fenced
+This is a code block
 
 
-    with two blank lines in it
+with two blank lines in it
+```
 
 Some more text

--- a/test/rule_tests/default_test_style.rb
+++ b/test/rule_tests/default_test_style.rb
@@ -2,4 +2,4 @@
 all
 
 exclude_rule "MD041"
-exclude_rule "MD046"
+#exclude_rule "MD046"

--- a/test/rule_tests/fenced_code_blocks_in_lists.md
+++ b/test/rule_tests/fenced_code_blocks_in_lists.md
@@ -1,0 +1,40 @@
+# test doc
+
+this is some text
+
+* This is a list item
+
+    ```fenced
+    this is a code block within the list item.
+    ```
+
+    with more text here
+
+* and another list item here
+
+And another paragraph.
+
+    But this code block {MD046}
+
+    is *NOT* in a list and should error.
+
+And in addition to that...
+
+    ```text
+    This code block is both indented
+    and fenced and should *also* error.
+    ```
+
+And finally:
+
+```text
+This is a code block
+
+    And this is a code block in a code block and should *not* error
+
+More stuff here
+```
+
+all
+
+{MD046:23}

--- a/test/rule_tests/inline_html_style.rb
+++ b/test/rule_tests/inline_html_style.rb
@@ -1,0 +1,2 @@
+all
+exclude_rule 'MD046'

--- a/test/rule_tests/reversed_link.md
+++ b/test/rule_tests/reversed_link.md
@@ -2,6 +2,8 @@ Go to (this website)[http://www.example.com] {MD011} {MD034}
 
 However, this shouldn't trigger inside code blocks:
 
-    myObj.getFiles("test")[0]
+```fenced
+myObj.getFiles("test")[0]
+```
 
 Nor inline code: `myobj.getFiles("test")[0]`


### PR DESCRIPTION
If a codeblock is nested inside of either a list or another
code block, it will have preceeding spaces, even if it is fenced, so
ignore those spaces.

Updates the testing ruleset to always include MD046 so we can catch
more issues like this in the future and updates tests accordingly.

Also adds various tests for this.

## Related Issues
Should close #217 #221 #233 I think.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [X] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences