### PR TITLE
Use require_relative to speed up requires

### DIFF
--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -1,10 +1,10 @@
-require 'mdl/cli'
-require 'mdl/config'
-require 'mdl/doc'
-require 'mdl/kramdown_parser'
-require 'mdl/ruleset'
-require 'mdl/style'
-require 'mdl/version'
+require_relative 'mdl/cli'
+require_relative 'mdl/config'
+require_relative 'mdl/doc'
+require_relative 'mdl/kramdown_parser'
+require_relative 'mdl/ruleset'
+require_relative 'mdl/style'
+require_relative 'mdl/version'
 
 require 'kramdown'
 

--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -1,5 +1,5 @@
 require 'kramdown'
-require 'mdl/kramdown_parser'
+require_relative 'kramdown_parser'
 
 module MarkdownLint
   ##


### PR DESCRIPTION
require_relative does not have to traverse the filesystem to find the
deps so it's faster than require.

See https://github.com/rspec/rspec-expectations/pull/476#issuecomment-35848905

Signed-off-by: Tim Smith <tsmith@chef.io>