### PR TITLE
Better error messages for styles; better docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,11 @@ might choose 72 characters, and another might have no line length limit at all
 Note: The value for `style_name` must either end with `.rb` or have `/` in it
 in order to tell `mdl` to look for a custom style, and not a built-in style.
 
+Note: When setting `style` in `mdlrc`, it is highly recommended that either a
+fully-qualified path be used, or that the relative values be passed in a form
+like `File.join(File.dirname(__FILE__), '.mdl.style')` so that the value is
+relative to the `mdlrc` and not the path the user happens to be in.
+
 Rulesets - Load a custom ruleset file. This option allows you to load custom
 rules in addition to those included with markdownlint.
 

--- a/lib/mdl/style.rb
+++ b/lib/mdl/style.rb
@@ -50,9 +50,23 @@ module MarkdownLint
     end
 
     def self.load(style_file, rules)
-      unless style_file.include?("/") or style_file.end_with?(".rb")
-        style_file = File.expand_path("../styles/#{style_file}.rb", __FILE__)
+      unless style_file.include?("/") || style_file.end_with?(".rb")
+        tmp = File.expand_path("../styles/#{style_file}.rb", __FILE__)
+        unless File.exist?(tmp)
+          STDERR.puts "#{style_file} does not appear to be a built-in style." +
+            " If you meant to pass in your own style file, it must contain" +
+            " a '/' or end in '.rb'. See https://github.com/markdownlint/" +
+            "markdownlint/blob/master/docs/configuration.md"
+          exit(1)
+        end
+        style_file = tmp
       end
+
+      unless File.exist?(style_file)
+        STDERR.puts "Style '#{style_file}' does not exist."
+        exit(1)
+      end
+
       style = new(rules)
       style.instance_eval(File.read(style_file), style_file)
       rules.select! {|r| style.rules.include?(r)}


### PR DESCRIPTION
This makes it clear to the user what went wrong and why:

```
$ ./bin/mdl -s 'test'
test does not appear to be a build-in style. If you meant to pass in your own style file, it must contain a '/' or end in '.rb'. See https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md
```

```
$ ./bin/mdl -s test.rb
Style 'test.rb' does not exist.
```

## Description
We didn't have a good error message, now we do.

## Related Issues
Closes #290

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [X] Feature branch is up-to-date with `master`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences