### PR TITLE
Enforce non-wrapping (#317)

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -332,11 +332,13 @@ lines inside code blocks.
 Tags: line_length
 
 Aliases: line-length
-Parameters: line_length, code_blocks, tables (number; default 80, boolean; default true)
+Parameters: line_length, code_blocks, hard_wrap, tables (number; default 80, boolean; default true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line
 up into multiple lines.
+
+Alternatively, if you specify that lines should not be hard wrapped, then hard wraps will trigger the rule. To fix this, remove line breaks inserted to limit line length.
 
 This rule has an exception where there is no whitespace beyond the configured
 line length. This allows you to still include items such as long URLs without

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -332,7 +332,7 @@ lines inside code blocks.
 Tags: line_length
 
 Aliases: line-length
-Parameters: line_length, code_blocks, hard_wrap, tables (number; default 80, boolean; default true)
+Parameters: line_length, code_blocks, style, tables (number; default 80, boolean; default true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -176,7 +176,7 @@ end
 rule "MD013", "Line length" do
   tags :line_length
   aliases 'line-length'
-  params :line_length => 80, :code_blocks => true, :tables => true, :hard_wrap => true
+  params :line_length => 80, :code_blocks => true, :tables => true, :style => :wrapped
   check do |doc|
     # Every line in the document that is part of a code block.
     codeblock_lines = doc.find_type_elements(:codeblock).map{
@@ -190,11 +190,11 @@ rule "MD013", "Line length" do
       |(l, e), i| (i + 1 < locations.size ?
                    (l..locations[i+1].first - 1) :
                    (l..doc.lines.count)).to_a if e.type == :table }.flatten
-    if params[:hard_wrap]
+    if params[:style] == :wrapped
       violation_lines = doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
       violation_lines -= codeblock_lines unless params[:code_blocks]
       violation_lines -= table_lines unless params[:tables]
-    else
+    elsif params[:style] == :not_wrapped
       violation_lines = []
       doc.lines.each_with_index do |text, linenum|
         next_line = doc.lines[linenum + 1]

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -191,29 +191,29 @@ rule "MD013", "Line length" do
                    (l..locations[i+1].first - 1) :
                    (l..doc.lines.count)).to_a if e.type == :table }.flatten
     if params[:hard_wrap]
-      overlines = doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
-      overlines -= codeblock_lines unless params[:code_blocks]
-      overlines -= table_lines unless params[:tables]
+      violation_lines = doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
+      violation_lines -= codeblock_lines unless params[:code_blocks]
+      violation_lines -= table_lines unless params[:tables]
     else
-      overlines = []
+      violation_lines = []
       doc.lines.each_with_index do |text, linenum|
         next_line = doc.lines[linenum + 1]
         
         if text.match(/.*[^\s]$/) and not next_line.nil? and not next_line.empty?
-          overlines << linenum + 1
+          violation_lines << linenum + 1
         end
       end
-      overlines -= codeblock_lines
-      overlines -= table_lines
-      overlines -= doc.find_type_elements(:header).map { |h| doc.element_linenumber(h) }
-      overlines -= doc.find_type_elements(:ul)
+      violation_lines -= codeblock_lines
+      violation_lines -= table_lines
+      violation_lines -= doc.find_type_elements(:header).map { |h| doc.element_linenumber(h) }
+      violation_lines -= doc.find_type_elements(:ul)
                       .map { |l| doc.find_type_elements(:li, true, l.children) }
                       .flatten.map { |i| doc.element_linenumber(i) }
-      overlines -= doc.find_type_elements(:ol)
+      violation_lines -= doc.find_type_elements(:ol)
                     .map { |l| doc.find_type_elements(:li, true, l.children) }
                     .flatten.map { |i| doc.element_linenumber(i) }
     end
-    overlines
+    violation_lines
 end
 end
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -212,6 +212,8 @@ rule "MD013", "Line length" do
       violation_lines -= doc.find_type_elements(:ol)
                     .map { |l| doc.find_type_elements(:li, true, l.children) }
                     .flatten.map { |i| doc.element_linenumber(i) }
+    else
+      raise "Line break style specified was not valid. Got '#{params[:style]}' but expected one of: 'wrapped', 'not_wrapped'."
     end
     violation_lines
 end

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -176,7 +176,7 @@ end
 rule "MD013", "Line length" do
   tags :line_length
   aliases 'line-length'
-  params :line_length => 80, :code_blocks => true, :tables => true, :style => :wrapped
+  params :line_length => 80, :code_blocks => true, :tables => true, :style => :stern
   check do |doc|
     # Every line in the document that is part of a code block.
     codeblock_lines = doc.find_type_elements(:codeblock).map{
@@ -190,7 +190,7 @@ rule "MD013", "Line length" do
       |(l, e), i| (i + 1 < locations.size ?
                    (l..locations[i+1].first - 1) :
                    (l..doc.lines.count)).to_a if e.type == :table }.flatten
-    if params[:style] == :wrapped
+    if params[:style] == :stern
       violation_lines = doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
       violation_lines -= codeblock_lines unless params[:code_blocks]
       violation_lines -= table_lines unless params[:tables]

--- a/test/rule_tests/long_lines.md
+++ b/test/rule_tests/long_lines.md
@@ -1,3 +1,10 @@
 This is a very very very very very very very very very very very very very very long line {MD013}
 
+This line is 80 characters which was the number of columns on an IBM punch card.
+Terminals adopted the same number of characters which meant this line would wrap,
+but in stern mode lines can be longer so long as there’s no whitespace after the limit.{MD013}
+
 This line however, while very long, doesn't have whitespace after the 80th columnwhichallowsforURLsandotherlongthings.
+
+That means that you can have long URLS without causing linting issues.
+For example: <http://llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.co.uk/history.php>

--- a/test/rule_tests/long_lines_not_broken.md
+++ b/test/rule_tests/long_lines_not_broken.md
@@ -1,0 +1,39 @@
+This is a very very very very very very very very very very very very very very long line
+
+# Headers are fine
+## Even followed by more headers
+
+This is a{MD013}
+broken line
+
+This is a short line which is okay
+
+A final short line.
+
+```text
+Code blocks
+can be broken too
+```
+
+| Tables | are  |
+|--------|------|
+| also   | okay |
+
+* Lists
+* must
+* be
+* fine
+
+  Even if there is a paragraph associated with an item{MD013}
+  But this should not be broken in this way
+
+  * And if there are sub items
+
+- This
+- style
+- too
+
+1. And
+1. this
+1. one
+    1. These can also have sublists

--- a/test/rule_tests/long_lines_not_broken_style.rb
+++ b/test/rule_tests/long_lines_not_broken_style.rb
@@ -1,0 +1,6 @@
+all
+rule 'MD013', :hard_wrap => false
+exclude_rule "MD004"
+exclude_rule "MD005"
+exclude_rule "MD022"
+exclude_rule "MD041"

--- a/test/rule_tests/long_lines_not_broken_style.rb
+++ b/test/rule_tests/long_lines_not_broken_style.rb
@@ -1,5 +1,5 @@
 all
-rule 'MD013', :hard_wrap => false
+rule 'MD013', :style => :not_wrapped
 exclude_rule "MD004"
 exclude_rule "MD005"
 exclude_rule "MD022"


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail, what problems does it solve? See [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) for tips on writing a good commit message -->

I’ve added configuration to MD01~2~3 to switch it to enforce not wrapping to allow us to enforce a consistent approach. This is described in https://cirosantilli.com/markdown-style-guide/#option-wrap-no

I’m not a ruby dev but this seems to work, but please let me know where I’ve not followed convention or where there are tricks to make things read better.

I’ve created the test cases I can think of. I’m not happy with adding to overlines as these are not lines that are ‘over’. Perhaps this should be renamed something line violation_lines?

I also think there’s a fair bit of duplication in this function now, and some in the file in general around extracting line numbers for various things. I tried extracting a helper function in the test but this didn’t work. I was wondering about adding some more functionality to doc.rb but wanted to check with others first.

## Related Issues
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Add a link to all corresponding Github issues here, using any [appropriate keywords](https://help.github.com/en/articles/closing-issues-using-keywords) as appropriate -->
Fixes #317.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
