### PR TITLE
Fix Dockerfile

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM alpine:3.11.3
+# We don't directly require 'etc' - but as of recently something we
+# do requires 'etc'... and in builds of ruby on nearly any distro that
+# seems to be part of core ruby... but in alpine it seems to not be there.
+# So we will statically list it here.
+# However, etc builds local bindings, which means you *also* need a long
+# list of build tools
 RUN echo "mdl:x:1000:mdl" >> /etc/group && \
     echo "mdl:x:1000:1000:mdl,,,:/home/mdl:/sbin/nologin" >> /etc/passwd && \
-    apk add --update --no-cache ruby && \
-    gem install mdl --no-document && \
+    apk add --update --no-cache ruby-dev cmake gcc libtool g++ make && \
+    gem install etc mdl --no-document && \
     mkdir /data
 WORKDIR /data
 USER mdl:mdl


### PR DESCRIPTION
# Description

Fixes #336

Turns out that something, somewhere, deep in one of our dependencies
now requires 'etc', but doesn't declare it... and it turns out that
that's in core ruby for like... MOST builds of ruby. Except alpine.
So just declare that in the Dockerfile.

I considered putting it in our gemspec, but we don't use it ourselves,
so that seems more inaccurate. And in fact in natiev usage, 0.10.0 seems
fine. So instead I think putting this in the Dockerfile is a more
correct workaround.

Before:
```
$ docker build -t markdownlint/markdownlint:latest -t markdownlint/markdownlint:0.10.0 .
Sending build context to Docker daemon  3.584kB
Step 1/6 : FROM alpine:3.11.3
 ---> e7d92cdc71fe
Step 2/6 : RUN echo "mdl:x:1000:mdl" >> /etc/group &&     echo "mdl:x:1000:1000:mdl,,,:/home/mdl:/sbin/nologin" >> /etc/passwd &&     apk add --update --no-cache ruby &&     gem install mdl --no-document &&     mkdir /data
 ---> Using cache
 ---> 71773ebf70be
Step 3/6 : WORKDIR /data
 ---> Using cache
 ---> 5776587ae519
Step 4/6 : USER mdl:mdl
 ---> Using cache
 ---> 45c36c2277f2
Step 5/6 : ENTRYPOINT ["mdl"]
 ---> Using cache
 ---> 85dbbd188559
Step 6/6 : CMD ["--help"]
 ---> Using cache
 ---> bca3a52dcabb
Successfully built bca3a52dcabb
Successfully tagged markdownlint/markdownlint:latest
Successfully tagged markdownlint/markdownlint:0.10.0

$ docker run --rm -v $PWD/data markdownlint/markdownlint --help
/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- etc (LoadError)
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/gems/2.6.0/gems/mixlib-shellout-3.1.2/lib/mixlib/shellout.rb:19:in `<top (required)>'
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/gems/2.6.0/gems/mdl-0.10.0/lib/mdl.rb:10:in `<top (required)>'
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/gems/2.6.0/gems/mdl-0.10.0/bin/mdl:7:in `rescue in <top (required)>'
	from /usr/lib/ruby/gems/2.6.0/gems/mdl-0.10.0/bin/mdl:2:in `<top (required)>'
	from /usr/bin/mdl:23:in `load'
	from /usr/bin/mdl:23:in `<main>'
/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- etc (LoadError)
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/gems/2.6.0/gems/mixlib-shellout-3.1.2/lib/mixlib/shellout.rb:19:in `<top (required)>'
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/gems/2.6.0/gems/mdl-0.10.0/lib/mdl.rb:10:in `<top (required)>'
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/gems/2.6.0/gems/mdl-0.10.0/bin/mdl:3:in `<top (required)>'
	from /usr/bin/mdl:23:in `load'
	from /usr/bin/mdl:23:in `<main>'
```

After:
```
$ docker build -t markdownlint/markdownlint:latest -t markdownlint/markdownlint:0.10.0 .
Sending build context to Docker daemon  3.584kB
Step 1/6 : FROM alpine:3.11.3
 ---> e7d92cdc71fe
Step 2/6 : RUN echo "mdl:x:1000:mdl" >> /etc/group &&     echo "mdl:x:1000:1000:mdl,,,:/home/mdl:/sbin/nologin" >> /etc/passwd &&     apk add --update --no-cache ruby-dev cmake gcc libtool g++ make &&     gem install etc mdl --no-document &&     mkdir /data
 ---> Using cache
 ---> 3135fd81d4b0
Step 3/6 : WORKDIR /data
 ---> Using cache
 ---> b14660dd7101
Step 4/6 : USER mdl:mdl
 ---> Using cache
 ---> d475ee61beff
Step 5/6 : ENTRYPOINT ["mdl"]
 ---> Using cache
 ---> e8dec510faca
Step 6/6 : CMD ["--help"]
 ---> Using cache
 ---> b71d06458d7a
Successfully built b71d06458d7a
Successfully tagged markdownlint/markdownlint:latest
Successfully tagged markdownlint/markdownlint:0.10.0

$ docker run --rm -v $PWD/data markdownlint/markdownlint --help
Usage: mdl [options] [FILE.md|DIR ...]
    -c, --config FILE                The configuration file to use
    -g, --git-recurse                Only process files known to git when given a directory
    -i, --[no-]ignore-front-matter   Ignore YAML front matter
    -j, --json                       JSON output
    -l, --list-rules                 Don't process any files, just list enabled rules
    -r, --rules RULE1,RULE2          Only process these rules
    -u, --rulesets RULESET1,RULESET2 Specify additional ruleset files to load
    -a, --[no-]show-aliases          Show rule alias instead of rule ID when viewing rules
    -w, --[no-]warnings              Show kramdown warnings
    -d, --skip-default-ruleset       Don't load the default markdownlint ruleset
    -s, --style STYLE                Load the given style
    -t, --tags TAG1,TAG2             Only process rules with these tags
    -v, --[no-]verbose               Increase verbosity
    -h, --help                       Show this message
    -V, --version                    Show version
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [X] Feature branch is up-to-date with `master`, if not - rebase it
- [X] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences