### PR TITLE
Fix `--git-recurse`

### DIFF
--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -66,7 +66,7 @@ module MarkdownLint
           Dir.chdir(filename) do
             cli.cli_arguments[i] =
               Mixlib::ShellOut.new("git ls-files '*.md' '*.markdown'")
-                              .run_command.stdout.lines
+                              .run_command.stdout.lines.map(&:strip)
           end
         else
           cli.cli_arguments[i] = Dir["#{filename}/**/*.{md,markdown}"]


### PR DESCRIPTION
# Description
 
Fix `--git-recurse`

0.10.0 ran rubocopy autocorrect across the codebase.

In the process it replaced:

```ruby
%x(git ls-files '*.md' '*.markdown').split("\n")
```

with

```ruby
Mixlib::ShellOut.new("git ls-files '*.md' '*.markdown'").run_command.stdout.lines
```

Moving away from %x{} and to Mixlib::ShellOut is great! But `.lines` is
*not* the same as `.split("\n")`.

`.lines` leaves newlines at the end of each entry in the array where
as splitting on newlines does not. So strip the entries.

Fixes #339

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [X] Feature branch is up-to-date with `master`, if not - rebase it
- [X] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences