### PR TITLE
Updated RULES.md to clarify the usage of MD004

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -141,7 +141,7 @@ Tags: bullet, ul
 
 Aliases: ul-style
 
-Parameters: style ("consistent", "asterisk", "plus", "dash"; default "consistent")
+Parameters: style (`:consistent`, `:asterisk`, `:plus`, `:dash`; default `:consistent`)
 
 This rule is triggered when the symbols used in the document for unordered
 list items do not match the configured unordered list style:

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -102,7 +102,7 @@ Tags: headers
 
 Aliases: header-style
 
-Parameters: style ("consistent", "atx", "atx_closed", "setext", "setext_with_atx"; default "consistent")
+Parameters: style (`:consistent`, `:atx`, `:atx_closed`, `:setext`, `:setext_with_atx`; default `:consistent`)
 
 This rule is triggered when different header styles (atx, setext, and 'closed'
 atx) are used in the same document:
@@ -332,7 +332,7 @@ lines inside code blocks.
 Tags: line_length
 
 Aliases: line-length
-Parameters: line_length, code_blocks, tables (number; default 80, boolean; default true)
+Parameters: line_length, code_blocks, tables (number; default 80, boolean; default true, boolean; default true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line
@@ -674,7 +674,7 @@ Tags: ol
 
 Aliases: ol-prefix
 
-Parameters: style ("one", "ordered"; default "one")
+Parameters: style (`:one`, `:ordered`; default `:one`)
 
 This rule is triggered on ordered lists that do not either start with '1.' or
 do not have a prefix that increases in numerical order (depending on the
@@ -880,8 +880,8 @@ Tags: hr
 
 Aliases: hr-style
 
-Parameters: style ("consistent", "---", "***", or other string specifying the
-horizontal rule; default "consistent")
+Parameters: style (`:consistent`, "---", "***", or other string specifying the
+horizontal rule; default `:consistent`)
 
 This rule is triggered when inconsistent styles of horizontal rules are used
 in the document:
@@ -1064,7 +1064,7 @@ Tags: code
 
 Aliases: code-block-style
 
-Parameters: style ("fenced", "indented", "consistent", default "fenced")
+Parameters: style (`:fenced`, `:indented`, `:consistent`, default `:fenced`)
 
 This rule is triggered when a different code block style is used than the
 configured one. For example, in the default configuration this rule is triggered


### PR DESCRIPTION
## Description
Based on the current documentation, since I wanted to use asterisk only for my unordered lists, I added this line to my rules file:
```ruby
rule 'MD004', :style => 'asterisk'
```
Unfortunately that didn't work, and all my lists were marked as incorrect. I could figure it out looking at the code itself, the correct input is:
```ruby
rule 'MD004', :style => :asterisk
```
I think it would be clearer in the doc with the change I'm proposing here.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [X] Feature branch is up-to-date with `master`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
