### PR TITLE
Updated doc.rb to preserve empty line at the end of the file

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -34,8 +34,8 @@ module MarkdownLint
       else
         @offset = 0
       end
-      # The -1 is to cause split to preserve an extra entry in the array so we can
-      # tell if there's a final newline in the file or not.
+      # The -1 is to cause split to preserve an extra entry in the array so we
+      # can tell if there's a final newline in the file or not.
       @lines = text.split(/\R/, -1)
       @parsed = Kramdown::Document.new(text, :input => 'MarkdownLint')
       @elements = @parsed.root.children

--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -11,7 +11,7 @@ module MarkdownLint
     # subtract 1 from a line number to get the correct line. The element_line*
     # methods take care of this for you.
 
-    attr_reader :raw_text, :lines, :parsed, :elements, :offset
+    attr_reader :lines, :parsed, :elements, :offset
 
     ##
     # A Kramdown::Document object containing the parsed markdown document.
@@ -27,7 +27,6 @@ module MarkdownLint
     # Create a new document given a string containing the markdown source
 
     def initialize(text, ignore_front_matter = false)
-      @raw_text = text
       regex = /^---\n(.*?)---\n\n?/m
       if ignore_front_matter && regex.match(text)
         @offset = regex.match(text).to_s.split("\n").length
@@ -35,7 +34,7 @@ module MarkdownLint
       else
         @offset = 0
       end
-      @lines = text.split(/\R/)
+      @lines = text.split(/\R/, -1)
       @parsed = Kramdown::Document.new(text, :input => 'MarkdownLint')
       @elements = @parsed.root.children
       add_annotations(@elements)

--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -34,6 +34,8 @@ module MarkdownLint
       else
         @offset = 0
       end
+      # The -1 is to cause split to preserve an extra entry in the array so we can
+      # tell if there's a final newline in the file or not.
       @lines = text.split(/\R/, -1)
       @parsed = Kramdown::Document.new(text, :input => 'MarkdownLint')
       @elements = @parsed.root.children

--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -11,7 +11,7 @@ module MarkdownLint
     # subtract 1 from a line number to get the correct line. The element_line*
     # methods take care of this for you.
 
-    attr_reader :lines, :parsed, :elements, :offset
+    attr_reader :raw_text, :lines, :parsed, :elements, :offset
 
     ##
     # A Kramdown::Document object containing the parsed markdown document.
@@ -27,6 +27,7 @@ module MarkdownLint
     # Create a new document given a string containing the markdown source
 
     def initialize(text, ignore_front_matter = false)
+      @raw_text = text
       regex = /^---\n(.*?)---\n\n?/m
       if ignore_front_matter && regex.match(text)
         @offset = regex.match(text).to_s.split("\n").length


### PR DESCRIPTION
## Description
Adding a raw_text attr_reader to allow for custom rules to access the raw text of the processed MD file.
Initial closed PR (git commits mess problems):
https://github.com/markdownlint/markdownlint/pull/347

## Related Issues
https://github.com/markdownlint/markdownlint/issues/346

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [X] Feature branch is up-to-date with `master`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
