### PR TITLE
Remove stack trace when file does not exist (#353)

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -48,8 +48,10 @@ module MarkdownLint
     def self.new_from_file(filename, ignore_front_matter = false)
       if filename == '-'
         new($stdin.read, ignore_front_matter)
-      else
+      elsif File.exist?(filename)
         new(File.read(filename, :encoding => 'UTF-8'), ignore_front_matter)
+      else
+        raise Errno::ENOENT, filename, []
       end
     end
 

--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -43,7 +43,8 @@ module MarkdownLint
     end
 
     ##
-    # Alternate 'constructor' passing in a filename
+    # Alternate 'constructor' passing in a filename. Exists with 1 if file
+    # doesn't exist
 
     def self.new_from_file(filename, ignore_front_matter = false)
       if filename == '-'
@@ -51,7 +52,8 @@ module MarkdownLint
       elsif File.exist?(filename)
         new(File.read(filename, :encoding => 'UTF-8'), ignore_front_matter)
       else
-        raise Errno::ENOENT, filename, []
+        $stderr << "#{Errno::ENOENT}: No such file or directory - #{filename}"
+        exit 1
       end
     end
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -224,6 +224,33 @@ class TestCli < Minitest::Test
     assert_equal(result[:stdout], expected)
   end
 
+  def test_graceful_not_found
+    file_path = "a/file/that/does/not/exist.md"
+    dir_path = "a/folder/that/does/not/exist"
+
+    file_result = run_cli(file_path)
+    dir_result = run_cli(dir_path)
+
+    file_expected = "Errno::ENOENT: No such file or directory - #{file_path}"
+    dir_expected = "Errno::ENOENT: No such file or directory - #{dir_path}"
+
+    # No normal output
+    assert_equal("", file_result[:stdout])
+    assert_equal("", dir_result[:stdout])
+
+    # Statuses are 1
+    assert_equal(1, file_result[:status])
+    assert_equal(1, file_result[:status])
+
+    # Stderr has no more than 3 lines (one for bundler, one for error msg, +1)
+    assert file_result[:stderr].split("\n").size <= 3
+    assert dir_result[:stderr].split("\n").size <= 3
+
+    # Check error message is correct
+    assert_equal(file_expected, file_result[:stderr].split("\n")[1])
+    assert_equal(dir_expected, dir_result[:stderr].split("\n")[1])
+  end
+
   private
 
   def run_cli_with_input(args, stdin)

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -234,7 +234,7 @@ class TestCli < Minitest::Test
     file_expected = "Errno::ENOENT: No such file or directory - #{file_path}"
     dir_expected = "Errno::ENOENT: No such file or directory - #{dir_path}"
 
-    # No normal output
+    # No stdout
     assert_equal('', file_result[:stdout])
     assert_equal('', dir_result[:stdout])
 
@@ -242,13 +242,9 @@ class TestCli < Minitest::Test
     assert_equal(1, file_result[:status])
     assert_equal(1, file_result[:status])
 
-    # Stderr has no more than 3 lines (one for bundler, one for error msg, +1)
-    assert file_result[:stderr].split("\n").size <= 3
-    assert dir_result[:stderr].split("\n").size <= 3
-
-    # Check error message is correct
-    assert_equal(file_expected, file_result[:stderr].split("\n")[1])
-    assert_equal(dir_expected, dir_result[:stderr].split("\n")[1])
+    # Check error message is expected
+    assert_equal(file_expected, file_result[:stderr])
+    assert_equal(dir_expected, dir_result[:stderr])
   end
 
   private

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -225,8 +225,8 @@ class TestCli < Minitest::Test
   end
 
   def test_graceful_not_found
-    file_path = "a/file/that/does/not/exist.md"
-    dir_path = "a/folder/that/does/not/exist"
+    file_path = 'a/file/that/does/not/exist.md'
+    dir_path = 'a/folder/that/does/not/exist'
 
     file_result = run_cli(file_path)
     dir_result = run_cli(dir_path)
@@ -235,8 +235,8 @@ class TestCli < Minitest::Test
     dir_expected = "Errno::ENOENT: No such file or directory - #{dir_path}"
 
     # No normal output
-    assert_equal("", file_result[:stdout])
-    assert_equal("", dir_result[:stdout])
+    assert_equal('', file_result[:stdout])
+    assert_equal('', dir_result[:stdout])
 
     # Statuses are 1
     assert_equal(1, file_result[:status])


### PR DESCRIPTION
Fixes #353

## Description

This change removes stack traces when a file does not exist, and tests this behaviour.

## Related Issues

Closes #353 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences

