### PR TITLE
Support for sublist styles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,3 +66,6 @@ Style/MultilineBlockChain:
 
 Style/NumericPredicate:
   Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -142,7 +142,7 @@ Tags: bullet, ul
 
 Aliases: ul-style
 
-Parameters: style (`:consistent`, `:asterisk`, `:plus`, `:dash`; default `:consistent`)
+Parameters: style (`:consistent`, `:asterisk`, `:plus`, `:dash`, `:sublist`; default `:consistent`)
 
 This rule is triggered when the symbols used in the document for unordered
 list items do not match the configured unordered list style:
@@ -160,7 +160,36 @@ document:
 
 Note: the configured list style can be a specific symbol to use (asterisk,
 plus, dash), or simply require that the usage be consistent within the
-document.
+document (consistent) or within a level (sublist).
+
+For sublist, each level must be consistent within a document, even if they
+are separate lists. So this is allowed:
+
+    * Item 1
+    * Item 2
+      - Item 2a
+        + Item 2a1
+      - Item 2b
+    * Item 3
+
+    Other stuff
+
+    * Item 1
+    * Item 2
+
+But this is not allowed:
+
+    * Item 1
+    * Item 2
+      - Item 2a
+        + Item 2a1
+      - Item 2b
+    * Item 3
+
+    Other stuff
+
+    - Item 1
+    - Item 2
 
 ## MD005 - Inconsistent indentation for list items at the same level
 

--- a/test/rule_tests/bulletd_list_sublist.md
+++ b/test/rule_tests/bulletd_list_sublist.md
@@ -1,0 +1,15 @@
+This is a document where the lists are consisent style per-sublist
+
+* stuff
+* other stuff
+  - indented stuff
+  - more indented stuff
+  + thing {MD004}
+  - stuff
+    + woah
+    + this
+    + is
+    + ok but...
+    - not this {MD004}
+    + but this
+* thing

--- a/test/rule_tests/bulletd_list_sublist_style.rb
+++ b/test/rule_tests/bulletd_list_sublist_style.rb
@@ -1,0 +1,1 @@
+rule 'MD004', :style => :sublist


### PR DESCRIPTION
Provide a style option to MD004 to allow sublists to differ in style
as long as they are internally consistent.

Closes #322

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences