### PR TITLE
Stop tests being run everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Continuous Integration
-on: [push, pull_request]
+on: 
+  push:
+    branches: master
+  pull_request:
+    branches: master
 jobs:
   markdown:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We weren't limiting branches, so'd get double-tests results, but the
one on your fork would fail. This fixes that.