### PR TITLE
Update unorder list indentation default to 3 spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Changed
+
+* Changed the default for MD007 to 3 spaces to match minimum spaces for ordered lists
+
 ## [v0.11.0] (2020-08-22)
 
 ### Fixed

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -218,7 +218,7 @@ Tags: bullet, ul, indentation
 
 Aliases: ul-indent
 
-Parameters: indent (number; default 2)
+Parameters: indent (number; default 3)
 
 This rule is triggered when list items are not indented by the configured
 number of spaces (default: 2).
@@ -233,9 +233,13 @@ Corrected Example:
     * List item
       * Nested list item indented by 2 spaces
 
-Rationale (2 space indent): indenting by 2 spaces allows the content of a
-nested list to be in line with the start of the content of the parent list
-when a single space is used after the list marker.
+Rationale (3 space indent): This matches the minimum possible indentation
+for _ordered_ lists (i.e Kramdown won't parse anything less than 3 spaces
+as a sublist on OLs), and since MD0005 requires consistent indentation
+across lists, anything less than three on this rule will cause a violation
+of MD005 if you have both kinds of lists in the same document.
+
+This means if you want to set this to 2, you'll need to disable MD005.
 
 Rationale (4 space indent): Same indent as code blocks, simpler for editors to
 implement. See

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -119,7 +119,8 @@ end
 rule 'MD007', 'Unordered list indentation' do
   tags :bullet, :ul, :indentation
   aliases 'ul-indent'
-  params :indent => 2
+  # Do not default to < 3, see PR#373 or the comments in RULES.md
+  params :indent => 3
   check do |doc|
     errors = []
     indents = doc.find_type(:ul).map do |e|

--- a/test/rule_tests/bulleted_list_not_at_beginning_of_line.md
+++ b/test/rule_tests/bulleted_list_not_at_beginning_of_line.md
@@ -1,14 +1,14 @@
 Some text
 
   * Item {MD006}
-    * Item
-    * Item
-      * Item
-    * Item
+     * Item
+     * Item
+        * Item
+     * Item
   * Item
   * Item
 
 Some more text
 
   * Item {MD006}
-    * Item
+     * Item

--- a/test/rule_tests/consistent_bullet_styles_asterisk.md
+++ b/test/rule_tests/consistent_bullet_styles_asterisk.md
@@ -1,3 +1,3 @@
 * Item
-  * Item
-  * Item
+   * Item
+   * Item

--- a/test/rule_tests/consistent_bullet_styles_dash.md
+++ b/test/rule_tests/consistent_bullet_styles_dash.md
@@ -1,3 +1,3 @@
 - Item
-  - Item
-  - Item
+   - Item
+   - Item

--- a/test/rule_tests/consistent_bullet_styles_plus.md
+++ b/test/rule_tests/consistent_bullet_styles_plus.md
@@ -1,3 +1,3 @@
 + Item
-  + Item
-  + Item
+   + Item
+   + Item

--- a/test/rule_tests/headers_good_with_issue_numbers.md
+++ b/test/rule_tests/headers_good_with_issue_numbers.md
@@ -6,7 +6,7 @@ See the following issues:
 
 * #1234
 * #5678 (and related)
-  * #5678
-  * #9101
+   * #5678
+   * #9101
 
 ## Heading 3

--- a/test/rule_tests/inconsistent_bullet_styles_asterisk.md
+++ b/test/rule_tests/inconsistent_bullet_styles_asterisk.md
@@ -1,9 +1,9 @@
 * Item
-  + Item {MD004}
-  - Item {MD004}
-  * Item
+   + Item {MD004}
+   - Item {MD004}
+   * Item
 
 > * Item
->   + Item {MD004}
->   - Item {MD004}
->   * Item
+>    + Item {MD004}
+>    - Item {MD004}
+>    * Item

--- a/test/rule_tests/inconsistent_bullet_styles_dash.md
+++ b/test/rule_tests/inconsistent_bullet_styles_dash.md
@@ -1,9 +1,9 @@
 - Item
-  * Item {MD004}
-  + Item {MD004}
-  - Item
+   * Item {MD004}
+   + Item {MD004}
+   - Item
 
 > - Item
->   * Item {MD004}
->   + Item {MD004}
->   - Item
+>    * Item {MD004}
+>    + Item {MD004}
+>    - Item

--- a/test/rule_tests/inconsistent_bullet_styles_plus.md
+++ b/test/rule_tests/inconsistent_bullet_styles_plus.md
@@ -1,9 +1,9 @@
 + Item
-  * Item {MD004}
-  - Item {MD004}
-  + Item
+   * Item {MD004}
+   - Item {MD004}
+   + Item
 
 > + Item
->   * Item {MD004}
->   - Item {MD004}
->   + Item
+>    * Item {MD004}
+>    - Item {MD004}
+>    + Item

--- a/test/rule_tests/incorrect_bullet_style_asterisk.md
+++ b/test/rule_tests/incorrect_bullet_style_asterisk.md
@@ -1,3 +1,3 @@
 * Item
-  - Item {MD004}
-  + Item {MD004}
+   - Item {MD004}
+   + Item {MD004}

--- a/test/rule_tests/incorrect_bullet_style_dash.md
+++ b/test/rule_tests/incorrect_bullet_style_dash.md
@@ -1,3 +1,3 @@
 * Item {MD004}
-  - Item
-  + Item {MD004}
+   - Item
+   + Item {MD004}

--- a/test/rule_tests/incorrect_bullet_style_plus.md
+++ b/test/rule_tests/incorrect_bullet_style_plus.md
@@ -1,3 +1,3 @@
 * Item {MD004}
-  - Item {MD004}
-  + Item
+   - Item {MD004}
+   + Item

--- a/test/rule_tests/lists_without_blank_lines.md
+++ b/test/rule_tests/lists_without_blank_lines.md
@@ -25,15 +25,15 @@ text
 text
 
 * list
-  * list
-    * list
+   * list
+      * list
 
 text
 
 * list
   with hanging indent
-  * list
-    with hanging indent
+   * list
+     with hanging indent
 * list
   with hanging indent
 


### PR DESCRIPTION
Kramdown will not recognize ordered list indentations of < 3 spaces.
Yet we require 2 for *un*orderder lists making them inconsistent.

Worse yet, MD005 wants you to be consistent across lists types, which
is impossible given the above, unless you change the default manually.

So lets just make it possible to comply with all lists by setting
*un*ordered lists to 3 to match ordered lists.

Closes #139

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences