### PR TITLE
Add support for the XDG Base Directory Specification

### DIFF
--- a/lib/mdl/cli.rb
+++ b/lib/mdl/cli.rb
@@ -6,7 +6,8 @@ module MarkdownLint
   class CLI
     include Mixlib::CLI
 
-    CONFIG_FILE = '.mdlrc'.freeze
+    CONFIG_FILE = 'mdlrc'.freeze
+    CONFIG_DOT_FILE = '.'.freeze + CONFIG_FILE
 
     banner "Usage: #{File.basename($PROGRAM_NAME)} [options] [FILE.md|DIR ...]"
 
@@ -21,7 +22,7 @@ module MarkdownLint
            :short => '-c',
            :long => '--config FILE',
            :description => 'The configuration file to use',
-           :default => CONFIG_FILE.to_s
+           :default => CONFIG_DOT_FILE.to_s
 
     option :verbose,
            :short => '-v',
@@ -113,9 +114,13 @@ module MarkdownLint
       # Load the config file if it's present
       filename = CLI.probe_config_file(config[:config_file])
 
-      # Only fall back to ~/.mdlrc if we are using the default value for -c
-      if filename.nil? && (config[:config_file] == CONFIG_FILE)
-        filename = File.expand_path("~/#{CONFIG_FILE}")
+      # Only fall back to the global config if we are using the default value for -c
+      if filename.nil? && (config[:config_file] == CONFIG_DOT_FILE)
+        filename = [
+          File.expand_path("~/#{CONFIG_DOT_FILE}"),
+          File.join(ENV.fetch('XDG_CONFIG_HOME', File.expand_path('~/.config')),
+                    CONFIG_FILE)
+        ].find(&File.method(:exist?))
       end
 
       if !filename.nil? && File.exist?(filename)


### PR DESCRIPTION
## Description
Adds an extra lookup path for the mdl config file to XDG_CONFIG_HOME.
In the interest of consistency and backwards compatibility the XDG
path check has a lower precedence than the ~/.mdlrc path.

## Related Issues
Closes #376

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [X] Feature branch is up-to-date with `master`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
