### PR TITLE
Utilise types instead file extensions

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,11 +3,13 @@
   description: Run markdownlint on your Markdown files
   entry: mdl
   language: ruby
-  files: \.(md|mdown|markdown)$
+  types:
+    - markdown
 
 - id: markdownlint_docker
   name: Markdownlint Docker
   description: Run markdown lint on your Markdown files using the project docker image
   language: docker_image
-  files: \.(md|mdown|markdown)$
+  types:
+    - markdown
   entry: markdownlint/markdownlint

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
   Exclude:
     - 'omnibus/bin/*'

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables = %w{mdl}
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_dependency 'kramdown', '~> 2.3'
   spec.add_dependency 'kramdown-parser-gfm', '~> 1.1'


### PR DESCRIPTION
Instead using file extensions, suggested to use types as the types are community driven, too and requires less maintenance if the type requires modifiying. See - https://github.com/pre-commit/identify/blob/master/identify/extensions.py

*Warning*: This method does not support the file extension `.mdown`. However, can be overriden in a `pre-commit-config.yaml` if needed. 

