### PR TITLE
Fix rubocop target version; lint versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6]
+        ruby: [2.7]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   NewCops: enable
   Exclude:
     - 'omnibus/bin/*'

--- a/lib/mdl/cli.rb
+++ b/lib/mdl/cli.rb
@@ -148,7 +148,7 @@ module MarkdownLint
       parts = parts.split(',') if parts.instance_of?(String)
       if parts.instance_of?(Array)
         inc = parts.reject { |p| p.start_with?('~') }
-        exc = parts.select { |p| p.start_with?('~') }.map { |p| p[1..-1] }
+        exc = parts.select { |p| p.start_with?('~') }.map { |p| p[1..] }
         if to_sym
           inc.map!(&:to_sym)
           exc.map!(&:to_sym)

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -234,7 +234,7 @@ rule 'MD014', 'Dollar signs used before commands without showing output' do
   aliases 'commands-show-output'
   check do |doc|
     doc.find_type_elements(:codeblock).select do |e|
-      !e.value.empty? and
+      !e.value.empty? &&
         !e.value.split(/\n+/).map { |l| l.match(/^\$\s/) }.include?(nil)
     end.map { |e| doc.element_linenumber(e) }
   end
@@ -245,7 +245,7 @@ rule 'MD018', 'No space after hash on atx style header' do
   aliases 'no-missing-space-atx'
   check do |doc|
     doc.find_type_elements(:header).select do |h|
-      doc.header_style(h) == :atx and doc.element_line(h).match(/^#+[^#\s]/)
+      doc.header_style(h) == :atx && doc.element_line(h).match(/^#+[^#\s]/)
     end.map { |h| doc.element_linenumber(h) }
   end
 end
@@ -255,7 +255,7 @@ rule 'MD019', 'Multiple spaces after hash on atx style header' do
   aliases 'no-multiple-space-atx'
   check do |doc|
     doc.find_type_elements(:header).select do |h|
-      doc.header_style(h) == :atx and doc.element_line(h).match(/^#+\s\s/)
+      doc.header_style(h) == :atx && doc.element_line(h).match(/^#+\s\s/)
     end.map { |h| doc.element_linenumber(h) }
   end
 end
@@ -266,8 +266,8 @@ rule 'MD020', 'No space inside hashes on closed atx style header' do
   check do |doc|
     doc.find_type_elements(:header).select do |h|
       doc.header_style(h) == :atx_closed \
-        and (doc.element_line(h).match(/^#+[^#\s]/) \
-             or doc.element_line(h).match(/[^#\s\\]#+$/))
+        && (doc.element_line(h).match(/^#+[^#\s]/) \
+             || doc.element_line(h).match(/[^#\s\\]#+$/))
     end.map { |h| doc.element_linenumber(h) }
   end
 end
@@ -278,8 +278,8 @@ rule 'MD021', 'Multiple spaces inside hashes on closed atx style header' do
   check do |doc|
     doc.find_type_elements(:header).select do |h|
       doc.header_style(h) == :atx_closed \
-        and (doc.element_line(h).match(/^#+\s\s/) \
-             or doc.element_line(h).match(/\s\s#+$/))
+        && (doc.element_line(h).match(/^#+\s\s/) \
+             || doc.element_line(h).match(/\s\s#+$/))
     end.map { |h| doc.element_linenumber(h) }
   end
 end
@@ -406,7 +406,7 @@ rule 'MD025', 'Multiple top level headers in the same document' do
       h[:level] == params[:level]
     end
     if !headers.empty? && (doc.element_linenumber(headers[0]) == 1)
-      headers[1..-1].map { |h| doc.element_linenumber(h) }
+      headers[1..].map { |h| doc.element_linenumber(h) }
     end
   end
 end
@@ -669,7 +669,7 @@ rule 'MD038', 'Spaces inside code span elements' do
     # block that happen to be parsed as code spans.
     doc.element_linenumbers(
       doc.find_type_elements(:codespan).select do |i|
-        i.value.match(/(^\s|\s$)/) and !i.value.include?("\n")
+        i.value.match(/(^\s|\s$)/) && !i.value.include?("\n")
       end,
     )
   end
@@ -681,8 +681,8 @@ rule 'MD039', 'Spaces inside link text' do
   check do |doc|
     doc.element_linenumbers(
       doc.find_type_elements(:a).reject { |e| e.children.empty? }.select do |e|
-        e.children.first.type == :text && e.children.last.type == :text and (
-          e.children.first.value.start_with?(' ') or
+        e.children.first.type == :text && e.children.last.type == :text && (
+          e.children.first.value.start_with?(' ') ||
           e.children.last.value.end_with?(' '))
       end,
     )
@@ -696,7 +696,7 @@ rule 'MD040', 'Fenced code blocks should have a language specified' do
     # Kramdown parses code blocks with language settings as code blocks with
     # the class attribute set to language-languagename.
     doc.element_linenumbers(doc.find_type_elements(:codeblock).select do |i|
-                              !i.attr['class'].to_s.start_with?('language-') and
+                              !i.attr['class'].to_s.start_with?('language-') &&
                                 !doc.element_line(i).start_with?('    ')
                             end)
   end

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables = %w{mdl}
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'kramdown', '~> 2.3'
   spec.add_dependency 'kramdown-parser-gfm', '~> 1.1'

--- a/test/rule_tests/spaces_inside_codespan_elements.md
+++ b/test/rule_tests/spaces_inside_codespan_elements.md
@@ -1,7 +1,8 @@
 `normal codespan element`
 
-` codespan element with space inside left` {MD038}
-
 `codespan element with space inside right ` {MD038}
 
-` codespan element with spaces inside ` {MD038}
+We SHOULD have the following two tests marked with MD038 failurs
+` codespan element with space inside left`
+` codespan element with spaces inside ` but
+kramdown doesn't see that as a codespans so we can't detect them anymore.

--- a/tools/test_location.rb
+++ b/tools/test_location.rb
@@ -10,7 +10,7 @@ text = File.read(ARGV[0])
 unless ARGV[1].nil?
   # If we provide a second argument, then start the document from line N of
   # the original file.
-  text = text.split("\n")[ARGV[1].to_i - 1..-1].join("\n")
+  text = text.split("\n")[ARGV[1].to_i - 1..].join("\n")
 end
 doc = MarkdownLint::Doc.new(text)
 headers = doc.find_type(:header)


### PR DESCRIPTION
* Target 2.7 - no need for back compat.
* One lint rule changes: arrays don't end in -1, they just end
* Kramdown no longer returns codespans that start with a space, so drop those rules, but keep the context
* Use less-precedent and/or to avoid bugs
