### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
   Exclude:
     - 'omnibus/bin/*'

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables = %w{mdl}
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_dependency 'kramdown', '~> 2.3'
   spec.add_dependency 'kramdown-parser-gfm', '~> 1.1'


### PR DESCRIPTION
We were only testing on 2.5 and above, but were claiming 2.4 in places
which broke RC and stuff. Drop 2.4.

I have another PR moving us to 2.7, but that has some other issues.