### PR TITLE
Fix directory argument with --git-recurse

### DIFF
--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -66,7 +66,8 @@ module MarkdownLint
           Dir.chdir(filename) do
             cli.cli_arguments[i] =
               Mixlib::ShellOut.new("git ls-files '*.md' '*.markdown'")
-                              .run_command.stdout.lines.map(&:strip)
+                              .run_command.stdout.lines
+                              .map { |m| File.join(filename, m.strip) }
           end
         else
           cli.cli_arguments[i] = Dir["#{filename}/**/*.{md,markdown}"]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? See [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) for tips on writing a good commit message -->

Need to include the directory when passing back the list of Markdown files.

Before:
```
$ mdl -v -g Homebrew
Loaded config from /usr/local/Homebrew/.mdlrc
Checking README.md...
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/lib/ruby/gems/2.6.0/gems/mdl-0.11.0/lib/mdl/doc.rb:50:in `read': No such file or directory @ rb_sysopen - README.md (Errno::ENOENT)
```

After:
```
$ mdl -v -g Homebrew
Loaded config from /usr/local/Homebrew/.mdlrc
Checking Homebrew/README.md...
Processing rule MD001
Processing rule MD002
...
```

## Related Issues
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Add a link to all corresponding Github issues here, using any [appropriate keywords](https://help.github.com/en/articles/closing-issues-using-keywords) as appropriate -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
