### PR TITLE
Add MD010 option to allow hard tabs in code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 * Changed the default for MD007 to 3 spaces to match minimum spaces for ordered lists
-* Added option `:code_blocks` to rule MD010. If set to false, hard tabs in code blocks
+* Added option `:ignore_code_blocks` to rule MD010. If set to true, hard tabs in code blocks
   will be ignored.
 
 ## [v0.11.0] (2020-08-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 * Changed the default for MD007 to 3 spaces to match minimum spaces for ordered lists
+* Added option `:code_blocks` to rule MD010. If set to false, hard tabs in code blocks
+  will be ignored.
 
 ## [v0.11.0] (2020-08-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Changed
 
 * Changed the default for MD007 to 3 spaces to match minimum spaces for ordered lists
-* Added option `:ignore_code_blocks` to rule MD010. If set to true, hard tabs in code blocks
-  will be ignored.
+* Added option `:ignore_code_blocks` to rule MD010. If set to true, hard tabs in
+  code blocks will be ignored.
 
 ## [v0.11.0] (2020-08-22)
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -306,7 +306,7 @@ Tags: whitespace, hard_tab
 
 Aliases: no-hard-tabs
 
-Parameters: code_blocks (boolean; default true)
+Parameters: ignore_code_blocks (boolean; default false)
 
 This rule is triggered by any lines that contain hard tab characters instead
 of using spaces for indentation. To fix this, replace any hard tab characters
@@ -325,7 +325,7 @@ Corrected example:
         * Spaces used to indent the list item instead
 
 You have the option to exclude this rule for code blocks. To do this, set the
-`code_blocks` parameter to false.
+`ignore_code_blocks` parameter to true.
 
 ## MD011 - Reversed link syntax
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -306,6 +306,8 @@ Tags: whitespace, hard_tab
 
 Aliases: no-hard-tabs
 
+Parameters: code_blocks (boolean; default true)
+
 This rule is triggered by any lines that contain hard tab characters instead
 of using spaces for indentation. To fix this, replace any hard tab characters
 with spaces instead.
@@ -321,6 +323,9 @@ Corrected example:
     Some text
 
         * Spaces used to indent the list item instead
+
+You have the option to exclude this rule for code blocks. To do this, set the
+`code_blocks` parameter to false.
 
 ## MD011 - Reversed link syntax
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -180,7 +180,6 @@ rule 'MD010', 'Hard tabs' do
     # Check for lines with hard tab
     hard_tab_lines = doc.matching_lines(/\t/)
     # Remove lines with hard tabs, if they stem from codeblock
-    # code_blocks parameter is
     hard_tab_lines -= codeblock_lines unless params[:code_blocks]
     hard_tab_lines
   end

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -166,10 +166,23 @@ rule 'MD009', 'Trailing spaces' do
 end
 
 rule 'MD010', 'Hard tabs' do
-  tags :whitespace, :hard_tab
+  tags :whitespace, :hard_tab, :code_blocks
   aliases 'no-hard-tabs'
+  params :code_blocks => false
   check do |doc|
-    doc.matching_lines(/\t/)
+    # Every line in the document that is part of a code block. Blank lines
+    # inside of a code block are acceptable.
+    codeblock_lines = doc.find_type_elements(:codeblock).map do |e|
+      (doc.element_linenumber(e)..
+               doc.element_linenumber(e) + e.value.lines.count).to_a
+    end.flatten
+
+    # Check for lines with hard tab
+    hard_tab_lines = doc.matching_lines(/\t/)
+    # Remove lines with hard tabs, if they stem from codeblock
+    # code_blocks parameter is
+    hard_tab_lines -= codeblock_lines unless params[:code_blocks]
+    hard_tab_lines
   end
 end
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -168,7 +168,7 @@ end
 rule 'MD010', 'Hard tabs' do
   tags :whitespace, :hard_tab, :code_blocks
   aliases 'no-hard-tabs'
-  params :code_blocks => false
+  params :code_blocks => true
   check do |doc|
     # Every line in the document that is part of a code block. Blank lines
     # inside of a code block are acceptable.

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -168,7 +168,7 @@ end
 rule 'MD010', 'Hard tabs' do
   tags :whitespace, :hard_tab
   aliases 'no-hard-tabs'
-  params :code_blocks => true
+  params :ignore_code_blocks => false
   check do |doc|
     # Every line in the document that is part of a code block. Blank lines
     # inside of a code block are acceptable.
@@ -180,7 +180,7 @@ rule 'MD010', 'Hard tabs' do
     # Check for lines with hard tab
     hard_tab_lines = doc.matching_lines(/\t/)
     # Remove lines with hard tabs, if they stem from codeblock
-    hard_tab_lines -= codeblock_lines unless params[:code_blocks]
+    hard_tab_lines -= codeblock_lines if params[:ignore_code_blocks]
     hard_tab_lines
   end
 end

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -166,7 +166,7 @@ rule 'MD009', 'Trailing spaces' do
 end
 
 rule 'MD010', 'Hard tabs' do
-  tags :whitespace, :hard_tab, :code_blocks
+  tags :whitespace, :hard_tab
   aliases 'no-hard-tabs'
   params :code_blocks => true
   check do |doc|

--- a/test/rule_tests/hard_tabs_code_blocks.md
+++ b/test/rule_tests/hard_tabs_code_blocks.md
@@ -1,0 +1,5 @@
+```makefile
+	text after hard tab
+```
+
+	text after illegal hard tab {MD010}

--- a/test/rule_tests/hard_tabs_code_blocks.md
+++ b/test/rule_tests/hard_tabs_code_blocks.md
@@ -3,3 +3,5 @@
 ```
 
 	text after illegal hard tab {MD010}
+
+Test	text {MD010}

--- a/test/rule_tests/hard_tabs_code_blocks.md
+++ b/test/rule_tests/hard_tabs_code_blocks.md
@@ -2,6 +2,4 @@
 	text after hard tab
 ```
 
-	text after illegal hard tab {MD010}
-
-Test	text {MD010}
+Text before hard tab	text after hard tab {MD010}

--- a/test/rule_tests/hard_tabs_code_blocks_style.rb
+++ b/test/rule_tests/hard_tabs_code_blocks_style.rb
@@ -1,3 +1,3 @@
 all
-rule 'MD010', :code_blocks => false
+rule 'MD010', :ignore_code_blocks => true
 exclude_rule 'MD041'

--- a/test/rule_tests/hard_tabs_code_blocks_style.rb
+++ b/test/rule_tests/hard_tabs_code_blocks_style.rb
@@ -1,1 +1,4 @@
+all
 rule 'MD010', :code_blocks => false
+exclude_rule 'MD041'
+exclude_rule 'MD040'

--- a/test/rule_tests/hard_tabs_code_blocks_style.rb
+++ b/test/rule_tests/hard_tabs_code_blocks_style.rb
@@ -1,0 +1,1 @@
+rule 'MD010', :code_blocks => false

--- a/test/rule_tests/hard_tabs_code_blocks_style.rb
+++ b/test/rule_tests/hard_tabs_code_blocks_style.rb
@@ -1,4 +1,3 @@
 all
 rule 'MD010', :code_blocks => false
 exclude_rule 'MD041'
-exclude_rule 'MD040'


### PR DESCRIPTION
## Description

This PR adds an option to ignore hard tabs (MD010) in code blocks. This is useful, as hard tabs might be part of the code inside these blocks (e.g., Makefiles).

This PR changes the following:

- The implementation of MD010 has changed and it is similar to the implementation of MD013. First, the lines of code blocks are identified. Then all lines with hard tabs are identified and finally lines that are within code blocks are removed from the list of lines with hard tabs.
- The parameter to check for or ignore hard tabs in code blocks is called `code_blocks`. Its default value is `true` which means code blocks should be checked. By have the default value set to `true` the new parameter does not affect the default behavior of mdl.
- I added the new parameter to the documentation and made a note in the changelog.
- I tried to set up a test (`files hard_tabs_code_blocks.md` and `hard_tabs_code_blocks_style.rb`).

## Open questions/problems:

- Should we rename the parameter to `ignore_code_blocks` as suggested in #395? I would prefer `ignore_code_blocks` a lot since it is more meaningful, but MD013 already uses the name `code_blocks` for a parameter with basically the same meaning (ignore rule for code blocks). So maybe the naming of the parameter(s) should be part of a new issue? Changing the parameter name of rule MD013 could break existing configurations.
- I added a test (files hard_tabs_code_blocks.md and hard_tabs_code_blocks_style.rb). I was able to make work for the most parts. However, it flags an error regarding rule MD040 (Fenced code blocks should have a language specified) in line 5. It seems that mdl identifies lines starting with a hard tab as code block. Is this intended and expected?
  - Due to the unclear test situation I did not mark the "Added tests" box below.
- I have no experience with Ruby so any hint or critical feedback is welcome. I did my best to follow the style and ideas of already implemented features and tests.
- I am not sure whether I am allowed to make the "good commit messages" box. :wink: 

## Related Issues

This PR is related to #395 

This PR is related to rule MD010

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [ ] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
