### PR TITLE
Introduce `ignore_code_blocks` parameter to MD013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   code blocks will be ignored.
 * Added option `:ignore_code_blocks` to rule MD013. If set to true, hard tabs in
   code blocks will be ignored. The option `:code_blocks` has been marked as
-  deprecated in the documentation. If `:code_blocks` is set to true in the
+  deprecated in the documentation. If `:code_blocks` is set to false in the
   configuration, a deprecation warning is printed.
 
 ## [v0.11.0] (2020-08-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   code blocks will be ignored.
 * Added option `:ignore_code_blocks` to rule MD013. If set to true, hard tabs in
   code blocks will be ignored. The option `:code_blocks` has been marked as
-  deprecated in the documentation.
+  deprecated in the documentation. If `:code_blocks` is set to true in the
+  configuration, a deprecation warning is printed.
 
 ## [v0.11.0] (2020-08-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Changed the default for MD007 to 3 spaces to match minimum spaces for ordered lists
 * Added option `:ignore_code_blocks` to rule MD010. If set to true, hard tabs in
   code blocks will be ignored.
+* Added option `:ignore_code_blocks` to rule MD013. If set to true, hard tabs in
+  code blocks will be ignored. The option `:code_blocks` has been marked as
+  deprecated in the documentation.
 
 ## [v0.11.0] (2020-08-22)
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -372,7 +372,7 @@ Tags: line_length
 
 Aliases: line-length
 
-Parameters: line_length, code_blocks, ignore_code_blocks, tables (number; default 80, boolean; default true, boolean; default false, boolean; default true)
+Parameters: line_length, ignore_code_blocks, code_blocks, tables (number; default 80, boolean; default false, boolean; default true, boolean; default true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -382,8 +382,11 @@ This rule has an exception where there is no whitespace beyond the configured
 line length. This allows you to still include items such as long URLs without
 being forced to break them in the middle.
 
-You also have the option to exclude this rule for code blocks and tables. To
-do this, set the `code_blocks` and/or `tables` parameters to false.
+You also have the option to exclude this rule for code blocks. To
+do this, set the `ignore_code_blocks` parameter to true. To exclude this rule
+for tables set the `tables` parameters to false.  Setting the parameter
+`code_blocks` to false to exclude the rule for code blocks is deprecated and
+will be removed in a future release.
 
 Code blocks are included in this rule by default since it is often a
 requirement for document readability, and tentatively compatible with code

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -372,7 +372,7 @@ Tags: line_length
 
 Aliases: line-length
 
-Parameters: line_length, code_blocks, tables (number; default 80, boolean; default true, boolean; default true)
+Parameters: line_length, code_blocks, ignore_code_blocks, tables (number; default 80, boolean; default true, boolean; default false, boolean; default true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -214,8 +214,9 @@ end
 rule 'MD013', 'Line length' do
   tags :line_length
   aliases 'line-length'
-  params :line_length => 80, :ignore_code_blocks => false, :code_blocks => true
-  params :tables => true
+  params :line_length => 80, :ignore_code_blocks => false, :code_blocks => true,
+         :tables => true
+
   check do |doc|
     # Every line in the document that is part of a code block.
     codeblock_lines = doc.find_type_elements(:codeblock).map do |e|

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -214,7 +214,7 @@ end
 rule 'MD013', 'Line length' do
   tags :line_length
   aliases 'line-length'
-  params :line_length => 80, :code_blocks => true, :ignore_code_blocks => false
+  params :line_length => 80, :ignore_code_blocks => false, :code_blocks => true
   params :tables => true
   check do |doc|
     # Every line in the document that is part of a code block.

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -214,7 +214,7 @@ end
 rule 'MD013', 'Line length' do
   tags :line_length
   aliases 'line-length'
-  params :line_length => 80, :code_blocks => true, :tables => true
+  params :line_length => 80, :code_blocks => true, :ignore_code_blocks => false, :tables => true
   check do |doc|
     # Every line in the document that is part of a code block.
     codeblock_lines = doc.find_type_elements(:codeblock).map do |e|
@@ -235,7 +235,7 @@ rule 'MD013', 'Line length' do
       end
     end.flatten
     overlines = doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
-    overlines -= codeblock_lines unless params[:code_blocks]
+    overlines -= codeblock_lines unless ( params[:code_blocks] or !params[:ignore_code_blocks] )
     overlines -= table_lines unless params[:tables]
     overlines
   end

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -235,7 +235,9 @@ rule 'MD013', 'Line length' do
       end
     end.flatten
     overlines = doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
-    overlines -= codeblock_lines unless ( params[:code_blocks] or !params[:ignore_code_blocks] )
+    if !params[:code_blocks] || params[:ignore_code_blocks]
+      overlines -= codeblock_lines
+    end
     overlines -= table_lines unless params[:tables]
     overlines
   end

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -214,7 +214,8 @@ end
 rule 'MD013', 'Line length' do
   tags :line_length
   aliases 'line-length'
-  params :line_length => 80, :code_blocks => true, :ignore_code_blocks => false, :tables => true
+  params :line_length => 80, :code_blocks => true, :ignore_code_blocks => false
+  params :tables => true
   check do |doc|
     # Every line in the document that is part of a code block.
     codeblock_lines = doc.find_type_elements(:codeblock).map do |e|

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -239,6 +239,11 @@ rule 'MD013', 'Line length' do
     overlines = doc.matching_lines(/^.{#{@params[:line_length]}}.*\s/)
     if !params[:code_blocks] || params[:ignore_code_blocks]
       overlines -= codeblock_lines
+      unless params[:code_blocks]
+        warn 'MD013 warning: Parameter :code_blocks is deprecated.'
+        warn '  Please replace \":code_blocks => false\" by '\
+             '\":ignore_code_blocks => true\" in your configuration.'
+      end
     end
     overlines -= table_lines unless params[:tables]
     overlines

--- a/test/rule_tests/long_lines_code_style.rb
+++ b/test/rule_tests/long_lines_code_style.rb
@@ -1,3 +1,3 @@
 all
-rule 'MD013', :code_blocks => false, :tables => false
+rule 'MD013', :code_blocks => false, :ignore_code_blocks => true, :tables => false
 exclude_rule 'MD041'

--- a/test/rule_tests/long_lines_code_style.rb
+++ b/test/rule_tests/long_lines_code_style.rb
@@ -1,3 +1,4 @@
 all
-rule 'MD013', :code_blocks => false, :ignore_code_blocks => true, :tables => false
+rule 'MD013', :code_blocks => false, :ignore_code_blocks => true,
+              :tables => false
 exclude_rule 'MD041'

--- a/test/rule_tests/long_lines_code_style.rb
+++ b/test/rule_tests/long_lines_code_style.rb
@@ -1,4 +1,3 @@
 all
-rule 'MD013', :code_blocks => false, :ignore_code_blocks => true,
-              :tables => false
+rule 'MD013', :code_blocks => false, :tables => false
 exclude_rule 'MD041'

--- a/test/rule_tests/md013_ignore_long_lines_in_code_block.md
+++ b/test/rule_tests/md013_ignore_long_lines_in_code_block.md
@@ -1,0 +1,10 @@
+This is a short line.
+
+This is a very very very very very very very very very very very very very very very very very very very very long line. {MD013}
+
+This is a short line.
+
+```text
+Here is a short line in a code block.
+Here is a very very very very very very very very very very very very very very very very very very very long line in a code block.
+```

--- a/test/rule_tests/md013_ignore_long_lines_in_code_block_style.rb
+++ b/test/rule_tests/md013_ignore_long_lines_in_code_block_style.rb
@@ -1,0 +1,3 @@
+all
+rule 'MD013', :ignore_code_blocks => true, :tables => false
+exclude_rule 'MD041'


### PR DESCRIPTION

## Description
MD010 has a new parameter `ignore_code_blocks` which is more verbose than the `code_blocks` parameter. This PR adds the new parameter to MD013.

This PR is supposed to deal with https://github.com/markdownlint/markdownlint/issues/398.

## Related Issues

https://github.com/markdownlint/markdownlint/issues/398

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
