### PR TITLE
Adds customisable documentation to rulesets and rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,9 @@ Style/OptionalBooleanParameter:
 Style/StringConcatenation:
   Enabled: false
 
+Style/Lambda:
+  EnforcedStyle: lambda
+
 # we do this a lot. it's very rubyish
 Style/MultilineBlockChain:
   Enabled: false

--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -112,7 +112,11 @@ module MarkdownLint
           end
         end
 
-        if !$stdout.tty? && !Config[:json] && !docs_to_print.include?(rule)
+        # If we're not in JSON mode (URLs are in the object), and we cannot
+        # make real links (checking if we have a TTY is an OK heuristic for that)
+        # than instead of making the output ugly with long URLs, we print them at the
+        # end. And of course we only want to print each URL once.
+        if !Config[:json] && !$stdout.tty? && !docs_to_print.include?(rule)
           docs_to_print << rule
         end
       end

--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -113,9 +113,10 @@ module MarkdownLint
         end
 
         # If we're not in JSON mode (URLs are in the object), and we cannot
-        # make real links (checking if we have a TTY is an OK heuristic for that)
-        # than instead of making the output ugly with long URLs, we print them at the
-        # end. And of course we only want to print each URL once.
+        # make real links (checking if we have a TTY is an OK heuristic for
+        # that) then, instead of making the output ugly with long URLs, we
+        # print them at the end. And of course we only want to print each URL
+        # once.
         if !Config[:json] && !$stdout.tty? && !docs_to_print.include?(rule)
           docs_to_print << rule
         end

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -1,3 +1,9 @@
+docs do |id, description|
+  url_hash = [id.downcase,
+              description.downcase.gsub(/[^a-z]+/, '-')].join('---')
+  "https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md##{url_hash}"
+end
+
 rule 'MD001', 'Header levels should only increment by one level at a time' do
   tags :headers
   aliases 'header-increment'

--- a/lib/mdl/ruleset.rb
+++ b/lib/mdl/ruleset.rb
@@ -3,9 +3,10 @@ module MarkdownLint
   class Rule
     attr_accessor :id, :description
 
-    def initialize(id, description, block)
+    def initialize(id, description, fallback_docs: nil, &block)
       @id = id
       @description = description
+      @generate_docs = fallback_docs
       @aliases = []
       @tags = []
       @params = {}
@@ -31,6 +32,14 @@ module MarkdownLint
       @params.update(params) unless params.nil?
       @params
     end
+
+    def docs(url)
+      @generate_docs = ->(_, _) { url }
+    end
+
+    def docs_url
+      @generate_docs&.call(id, description)
+    end
   end
 
   # defines a ruleset
@@ -42,12 +51,17 @@ module MarkdownLint
     end
 
     def rule(id, description, &block)
-      @rules[id] = Rule.new(id, description, block)
+      @rules[id] =
+        Rule.new(id, description, :fallback_docs => @fallback_docs, &block)
     end
 
     def load(rules_file)
       instance_eval(File.read(rules_file), rules_file)
       @rules
+    end
+
+    def docs(url = nil, &block)
+      @fallback_docs = block_given? ? block : ->(_, _) { url }
     end
 
     def load_default

--- a/lib/mdl/ruleset.rb
+++ b/lib/mdl/ruleset.rb
@@ -7,6 +7,7 @@ module MarkdownLint
       @id = id
       @description = description
       @generate_docs = fallback_docs
+      @docs_overridden = false
       @aliases = []
       @tags = []
       @params = {}
@@ -34,7 +35,10 @@ module MarkdownLint
     end
 
     def docs(url)
-      @generate_docs = ->(_, _) { url }
+      raise 'A docs url is already set within this rule' if @docs_overridden
+
+      @generate_docs = lambda { |_, _| url }
+      @docs_overridden = true
     end
 
     def docs_url
@@ -61,7 +65,11 @@ module MarkdownLint
     end
 
     def docs(url = nil, &block)
-      @fallback_docs = block_given? ? block : ->(_, _) { url }
+      if block_given? && !url.nil?
+        raise ArgumentError, 'Give either a URL or a block, not both'
+      end
+
+      @fallback_docs = block_given? ? block : lambda { |_, _| url }
     end
 
     def load_default

--- a/lib/mdl/ruleset.rb
+++ b/lib/mdl/ruleset.rb
@@ -34,10 +34,14 @@ module MarkdownLint
       @params
     end
 
-    def docs(url)
+    def docs(url = nil, &block)
+      if block_given? != url.nil?
+        raise ArgumentError, 'Give either a URL or a block, not both'
+      end
+
       raise 'A docs url is already set within this rule' if @docs_overridden
 
-      @generate_docs = lambda { |_, _| url }
+      @generate_docs = block_given? ? block : lambda { |_, _| url }
       @docs_overridden = true
     end
 
@@ -65,7 +69,7 @@ module MarkdownLint
     end
 
     def docs(url = nil, &block)
-      if block_given? && !url.nil?
+      if block_given? != url.nil?
         raise ArgumentError, 'Give either a URL or a block, not both'
       end
 

--- a/test/fixtures/docs_ruleset_1.rb
+++ b/test/fixtures/docs_ruleset_1.rb
@@ -1,0 +1,16 @@
+docs 'https://example.com/static-docs'
+
+rule 'MY002', 'Documents must start with A' do
+  tags :opinionated
+  check do |doc|
+    [1] if doc.lines[0] != 'A'
+  end
+end
+
+rule 'MY003', 'Documents must start with B' do
+  tags :opinionated
+  docs 'https://example.com/override-docs'
+  check do |doc|
+    [1] if doc.lines[0] != 'B'
+  end
+end

--- a/test/fixtures/docs_ruleset_2.rb
+++ b/test/fixtures/docs_ruleset_2.rb
@@ -1,0 +1,29 @@
+require 'digest/md5'
+
+docs do |id, description|
+  "https://example.com/#{id}##{Digest::MD5.hexdigest(description)}"
+end
+
+rule 'MY004', 'Documents must start with C' do
+  tags :opinionated
+  check do |doc|
+    [1] if doc.lines[0] != 'C'
+  end
+end
+
+rule 'MY005', 'Documents must start with D' do
+  tags :opinionated
+  docs 'https://example.com/override-docs'
+  check do |doc|
+    [1] if doc.lines[0] != 'D'
+  end
+end
+
+docs 'https://example.com/later-declaration'
+
+rule 'MY006', 'Documents must start with E' do
+  tags :opinionated
+  check do |doc|
+    [1] if doc.lines[0] != 'E'
+  end
+end

--- a/test/fixtures/docs_ruleset_2.rb
+++ b/test/fixtures/docs_ruleset_2.rb
@@ -19,6 +19,19 @@ rule 'MY005', 'Documents must start with D' do
   end
 end
 
+rule 'MY007', 'Documents must start with F' do
+  tags :opinionated
+
+  docs do |id, description|
+    hash = description.downcase.gsub(/[^a-z]+/, '-')
+    "https://example.com/dynamic-override/#{id}##{hash}"
+  end
+
+  check do |doc|
+    [1] if doc.lines[0] != 'F'
+  end
+end
+
 docs 'https://example.com/later-declaration'
 
 rule 'MY006', 'Documents must start with E' do

--- a/test/fixtures/fake_tty.rb
+++ b/test/fixtures/fake_tty.rb
@@ -1,0 +1,5 @@
+# A hacky 'ruleset' file which forces an externally run
+# mdl instance to believe it's in a TTY, used for testing.
+def $stdout.tty?
+  true
+end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -23,6 +23,7 @@ class TestCli < Minitest::Test
     assert_equal('', result[:stderr])
     d = JSON.parse(result[:stdout])
     assert_match(d[0]['rule'], 'MD002')
+    assert_match(d[0]['docs'], 'https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md002---first-header-should-be-a-top-level-header')
   end
 
   def test_default_ruleset_loading
@@ -202,7 +203,7 @@ class TestCli < Minitest::Test
     )
     result = run_cli(path.to_s)
     lines_output = result[:stdout].lines
-    interested_lines = lines_output[0..(lines_output.count - 3)]
+    interested_lines = lines_output[0...lines_output.index("\n")]
     files_with_issues = interested_lines.map { |l| l.split(':')[0] }.sort
     assert_equal(files_with_issues, ["#{path}/bar.markdown", "#{path}/foo.md"])
   end
@@ -218,7 +219,8 @@ class TestCli < Minitest::Test
       #{path}/jekyll_post.md:16: MD001 Header levels should only increment by one level at a time
       #{path}/jekyll_post_2.md:16: MD001 Header levels should only increment by one level at a time
 
-      A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+      Further documentation is available for these failures:
+       - MD001: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md001---header-levels-should-only-increment-by-one-level-at-a-time
     OUTPUT
 
     assert_equal(result[:stdout], expected)
@@ -237,10 +239,68 @@ class TestCli < Minitest::Test
     assert_equal(result[:stdout], '')
   end
 
+  def test_printing_url_links_in_tty
+    result = run_cli_as_tty('-r MD002', "## header2\n")
+
+    link_text = 'MD002'
+    url = 'https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md002---first-header-should-be-a-top-level-header'
+    expected_link = "\e]8;;#{url}\e\\#{link_text}\e]8;;\e\\"
+
+    expected = <<~OUTPUT
+      (stdin):1: #{expected_link} First header should be a top level header
+    OUTPUT
+
+    assert_equal(result[:stdout], expected)
+  end
+
+  def test_printing_url_links_outside_tty
+    result = run_cli_with_input('-r MD002', "## header2\n")
+
+    url = 'https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md002---first-header-should-be-a-top-level-header'
+
+    expected = <<~OUTPUT
+      (stdin):1: MD002 First header should be a top level header
+
+      Further documentation is available for these failures:
+       - MD002: #{url}
+    OUTPUT
+
+    assert_equal(result[:stdout], expected)
+  end
+
+  def test_docs_declaration
+    ruleset1 = File.expand_path('./fixtures/docs_ruleset_1.rb', __dir__)
+    ruleset2 = File.expand_path('./fixtures/docs_ruleset_2.rb', __dir__)
+
+    result = run_cli_with_input("-d -u #{ruleset1},#{ruleset2}", "!\n")
+
+    expected = <<~OUTPUT
+      (stdin):1: MY002 Documents must start with A
+      (stdin):1: MY003 Documents must start with B
+      (stdin):1: MY004 Documents must start with C
+      (stdin):1: MY005 Documents must start with D
+      (stdin):1: MY006 Documents must start with E
+
+      Further documentation is available for these failures:
+       - MY002: https://example.com/static-docs
+       - MY003: https://example.com/override-docs
+       - MY004: https://example.com/MY004#364fe83d86ba1cdcc2ea87aec2fc5ec0
+       - MY005: https://example.com/override-docs
+       - MY006: https://example.com/later-declaration
+    OUTPUT
+
+    assert_equal(result[:stdout], expected)
+  end
+
   private
 
   def run_cli_with_input(args, stdin)
     run_cmd("#{mdl_script} -c #{default_rc_file} #{args}", stdin)
+  end
+
+  def run_cli_as_tty(args, stdin)
+    fake_tty = File.expand_path('./fixtures/fake_tty.rb', __dir__)
+    run_cmd("#{mdl_script} -c #{default_rc_file} -u #{fake_tty} #{args}", stdin)
   end
 
   def run_cli_without_rc_flag(args)

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -280,6 +280,7 @@ class TestCli < Minitest::Test
       (stdin):1: MY004 Documents must start with C
       (stdin):1: MY005 Documents must start with D
       (stdin):1: MY006 Documents must start with E
+      (stdin):1: MY007 Documents must start with F
 
       Further documentation is available for these failures:
        - MY002: https://example.com/static-docs
@@ -287,9 +288,10 @@ class TestCli < Minitest::Test
        - MY004: https://example.com/MY004#364fe83d86ba1cdcc2ea87aec2fc5ec0
        - MY005: https://example.com/override-docs
        - MY006: https://example.com/later-declaration
+       - MY007: https://example.com/dynamic-override/MY007#documents-must-start-with-f
     OUTPUT
 
-    assert_equal(result[:stdout], expected)
+    assert_equal(expected, result[:stdout])
   end
 
   private


### PR DESCRIPTION
## Description
Provides the 'docs' method in the ruleset and rules DSLs, allowing specification of either a static URL, or (in the case of ruleset docs) a block for generating a URL from the id and description of the rule.

Adds 'docs' key to JSON output, and hyperlinked ID/alias to terminal emulator output if supported (with graceful fallback)

Here are screenshots of this in action from my machine. (I use iTerm2, holding 'command' on my mac over a hyperlink allows me to click on it and shows the URL at the bottom of the window — as described in [this document explaining the process & graceful fallback](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda))

Failing rules have (templated) URLs hyperlinked from their IDs:
![rule-ids-have-links](https://user-images.githubusercontent.com/42999/148457983-d72aa177-c27b-4bcb-b0ce-78ad918c32a3.png)

Static URLs can override the templated ones on a per-rule basis:
![static-urls-too](https://user-images.githubusercontent.com/42999/148458049-966d48ae-f965-45a1-b8df-8260bd06a32f.png)

JSON includes docs key:
![JSON includes docs key](https://user-images.githubusercontent.com/42999/148458083-058cbc7b-4a5c-472d-80d1-26cf24125cac.png)

## Related Issues
Resolves #406

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
