### PR TITLE
MD040: Mention how to get no syntax highlighting

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1075,6 +1075,8 @@ To fix this, add a language specifier to the code block:
     echo Hello world
     ```
 
+If no specific language is used, you can specify `text` as language.
+
 ## MD041 - First line in file should be a top level header
 
 Tags: headers


### PR DESCRIPTION
## Description

MD040 requires the use of a language specified for fenced code blocks but lacked clarification on what to use when no specific language was used.  In these cases it is suggested to use `text` as language specifier.

## Related Issues

These are related but not really fixed by this PR.
https://github.com/markdownlint/markdownlint/issues/314
https://github.com/markdownlint/markdownlint/issues/87

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
