### PR TITLE
Substibute Travis for GHA in CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,8 @@ promote this, we require that all pull requests to meet these specifications:
   regressions, we require tests for all new/changed functionality in
   Markdownlint. Test positive and negative scenarios, try to break the new code
   now.
-* **Green CI Tests:** We use [Travis
-  CI](https://travis-ci.org/markdownlint/markdownlint) to test all pull
+* **Green CI Tests:** We use [GitHub
+  Actions](https://github.com/markdownlint/markdownlint/actions) to test all pull
   requests. We require these test runs to succeed on every pull request before
   being merged.
 


### PR DESCRIPTION
## Description

When CI was moved from Travis to GitHub Actions in #331, the CONTRIBUTING document wasn’t updated accordingly.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (non-breaking change that does not add functionality but updates documentation)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
