### PR TITLE
Fix docker builds

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11.3
+FROM alpine:3.16.2
 # Standard library gems used by markdownlint, such as 'etc' and 'json', are
 # not installed by default in Alpine Linux distros, since the current policy
 # is to have small packages with extra functionality (standard library

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -19,8 +19,8 @@ docker run --rm -v ${PWD}:/data markdownlint/markdownlint .
 The following will tag and upload a new release. Replace X.Y.Z as appropriate.
 
 ```shell
-docker build -t markdownlint/markdownlint:latest \
+podman build -t markdownlint/markdownlint:latest \
     -t markdownlint/markdownlint:X.Y.Z .
-docker push markdownlint/markdownlint:latest
-docker push markdownlint/markdownling:X.Y.Z
+podman push markdownlint/markdownlint:latest
+podman push markdownlint/markdownling:X.Y.Z
 ```


### PR DESCRIPTION
Needed a newer version of alpine to be able to use modern ruby.

Fixed build instructions to use podman instead of docker.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

