### PR TITLE
Fix CI for new branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Continuous Integration
 on: 
   push:
-    branches: master
+    branches: main
   pull_request:
-    branches: master
+    branches: main
 jobs:
   markdown:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Moved `master` -> `main`, but need to update CI.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
