### PR TITLE
apply markdownlint on RULES.md

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1,44 +1,44 @@
 
 * [Rules](#rules)
-    * [MD001 - Header levels should only increment by one level at a time](#md001---header-levels-should-only-increment-by-one-level-at-a-time)
-    * [MD002 - First header should be a top level header](#md002---first-header-should-be-a-top-level-header)
-    * [MD003 - Header style](#md003---header-style)
-    * [MD004 - Unordered list style](#md004---unordered-list-style)
-    * [MD005 - Inconsistent indentation for list items at the same level](#md005---inconsistent-indentation-for-list-items-at-the-same-level)
-    * [MD006 - Consider starting bulleted lists at the beginning of the line](#md006---consider-starting-bulleted-lists-at-the-beginning-of-the-line)
-    * [MD007 - Unordered list indentation](#md007---unordered-list-indentation)
-    * [MD009 - Trailing spaces](#md009---trailing-spaces)
-    * [MD010 - Hard tabs](#md010---hard-tabs)
-    * [MD011 - Reversed link syntax](#md011---reversed-link-syntax)
-    * [MD012 - Multiple consecutive blank lines](#md012---multiple-consecutive-blank-lines)
-    * [MD013 - Line length](#md013---line-length)
-    * [MD014 - Dollar signs used before commands without showing output](#md014---dollar-signs-used-before-commands-without-showing-output)
-    * [MD018 - No space after hash on atx style header](#md018---no-space-after-hash-on-atx-style-header)
-    * [MD019 - Multiple spaces after hash on atx style header](#md019---multiple-spaces-after-hash-on-atx-style-header)
-    * [MD020 - No space inside hashes on closed atx style header](#md020---no-space-inside-hashes-on-closed-atx-style-header)
-    * [MD021 - Multiple spaces inside hashes on closed atx style header](#md021---multiple-spaces-inside-hashes-on-closed-atx-style-header)
-    * [MD022 - Headers should be surrounded by blank lines](#md022---headers-should-be-surrounded-by-blank-lines)
-    * [MD023 - Headers must start at the beginning of the line](#md023---headers-must-start-at-the-beginning-of-the-line)
-    * [MD024 - Multiple headers with the same content](#md024---multiple-headers-with-the-same-content)
-    * [MD025 - Multiple top level headers in the same document](#md025---multiple-top-level-headers-in-the-same-document)
-    * [MD026 - Trailing punctuation in header](#md026---trailing-punctuation-in-header)
-    * [MD027 - Multiple spaces after blockquote symbol](#md027---multiple-spaces-after-blockquote-symbol)
-    * [MD028 - Blank line inside blockquote](#md028---blank-line-inside-blockquote)
-    * [MD029 - Ordered list item prefix](#md029---ordered-list-item-prefix)
-    * [MD030 - Spaces after list markers](#md030---spaces-after-list-markers)
-    * [MD031 - Fenced code blocks should be surrounded by blank lines](#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines)
-    * [MD032 - Lists should be surrounded by blank lines](#md032---lists-should-be-surrounded-by-blank-lines)
-    * [MD033 - Inline HTML](#md033---inline-html)
-    * [MD034 - Bare URL used](#md034---bare-url-used)
-    * [MD035 - Horizontal rule style](#md035---horizontal-rule-style)
-    * [MD036 - Emphasis used instead of a header](#md036---emphasis-used-instead-of-a-header)
-    * [MD037 - Spaces inside emphasis markers](#md037---spaces-inside-emphasis-markers)
-    * [MD038 - Spaces inside code span elements](#md038---spaces-inside-code-span-elements)
-    * [MD039 - Spaces inside link text](#md039---spaces-inside-link-text)
-    * [MD040 - Fenced code blocks should have a language specified](#md040---fenced-code-blocks-should-have-a-language-specified)
-    * [MD041 - First line in file should be a top level header](#md041---first-line-in-file-should-be-a-top-level-header)
-    * [MD046 - Code block style](#md046---code-block-style)
-    * [MD047 - File should end with a single newline character](#md047---file-should-end-with-a-single-newline-character)
+   * [MD001 - Header levels should only increment by one level at a time](#md001---header-levels-should-only-increment-by-one-level-at-a-time)
+   * [MD002 - First header should be a top level header](#md002---first-header-should-be-a-top-level-header)
+   * [MD003 - Header style](#md003---header-style)
+   * [MD004 - Unordered list style](#md004---unordered-list-style)
+   * [MD005 - Inconsistent indentation for list items at the same level](#md005---inconsistent-indentation-for-list-items-at-the-same-level)
+   * [MD006 - Consider starting bulleted lists at the beginning of the line](#md006---consider-starting-bulleted-lists-at-the-beginning-of-the-line)
+   * [MD007 - Unordered list indentation](#md007---unordered-list-indentation)
+   * [MD009 - Trailing spaces](#md009---trailing-spaces)
+   * [MD010 - Hard tabs](#md010---hard-tabs)
+   * [MD011 - Reversed link syntax](#md011---reversed-link-syntax)
+   * [MD012 - Multiple consecutive blank lines](#md012---multiple-consecutive-blank-lines)
+   * [MD013 - Line length](#md013---line-length)
+   * [MD014 - Dollar signs used before commands without showing output](#md014---dollar-signs-used-before-commands-without-showing-output)
+   * [MD018 - No space after hash on atx style header](#md018---no-space-after-hash-on-atx-style-header)
+   * [MD019 - Multiple spaces after hash on atx style header](#md019---multiple-spaces-after-hash-on-atx-style-header)
+   * [MD020 - No space inside hashes on closed atx style header](#md020---no-space-inside-hashes-on-closed-atx-style-header)
+   * [MD021 - Multiple spaces inside hashes on closed atx style header](#md021---multiple-spaces-inside-hashes-on-closed-atx-style-header)
+   * [MD022 - Headers should be surrounded by blank lines](#md022---headers-should-be-surrounded-by-blank-lines)
+   * [MD023 - Headers must start at the beginning of the line](#md023---headers-must-start-at-the-beginning-of-the-line)
+   * [MD024 - Multiple headers with the same content](#md024---multiple-headers-with-the-same-content)
+   * [MD025 - Multiple top level headers in the same document](#md025---multiple-top-level-headers-in-the-same-document)
+   * [MD026 - Trailing punctuation in header](#md026---trailing-punctuation-in-header)
+   * [MD027 - Multiple spaces after blockquote symbol](#md027---multiple-spaces-after-blockquote-symbol)
+   * [MD028 - Blank line inside blockquote](#md028---blank-line-inside-blockquote)
+   * [MD029 - Ordered list item prefix](#md029---ordered-list-item-prefix)
+   * [MD030 - Spaces after list markers](#md030---spaces-after-list-markers)
+   * [MD031 - Fenced code blocks should be surrounded by blank lines](#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines)
+   * [MD032 - Lists should be surrounded by blank lines](#md032---lists-should-be-surrounded-by-blank-lines)
+   * [MD033 - Inline HTML](#md033---inline-html)
+   * [MD034 - Bare URL used](#md034---bare-url-used)
+   * [MD035 - Horizontal rule style](#md035---horizontal-rule-style)
+   * [MD036 - Emphasis used instead of a header](#md036---emphasis-used-instead-of-a-header)
+   * [MD037 - Spaces inside emphasis markers](#md037---spaces-inside-emphasis-markers)
+   * [MD038 - Spaces inside code span elements](#md038---spaces-inside-code-span-elements)
+   * [MD039 - Spaces inside link text](#md039---spaces-inside-link-text)
+   * [MD040 - Fenced code blocks should have a language specified](#md040---fenced-code-blocks-should-have-a-language-specified)
+   * [MD041 - First line in file should be a top level header](#md041---first-line-in-file-should-be-a-top-level-header)
+   * [MD046 - Code block style](#md046---code-block-style)
+   * [MD047 - File should end with a single newline character](#md047---file-should-end-with-a-single-newline-character)
 
 # Rules
 
@@ -55,27 +55,30 @@ Aliases: header-increment
 This rule is triggered when you skip header levels in a markdown document, for
 example:
 
-    # Header 1
+```markdown
+# Header 1
 
-    ### Header 3
+### Header 3
 
-    We skipped out a 2nd level header in this document
+We skipped out a 2nd level header in this document
+```
 
 When using multiple header levels, nested headers should increase by only one
 level at a time:
 
-    # Header 1
+```markdown
+# Header 1
 
-    ## Header 2
+## Header 2
 
-    ### Header 3
+### Header 3
 
-    #### Header 4
+#### Header 4
 
-    ## Another Header 2
+## Another Header 2
 
-    ### Another Header 3
-
+### Another Header 3
+```
 
 ## MD002 - First header should be a top level header
 
@@ -87,15 +90,19 @@ Parameters: level (number; default 1)
 
 This rule is triggered when the first header in the document isn't a h1 header:
 
-    ## This isn't a H1 header
+```markdown
+## This isn't a H1 header
 
-    ### Another header
+### Another header
+```
 
 The first header in the document should be a h1 header:
 
-    # Start with a H1 header
+```markdown
+# Start with a H1 header
 
-    ## Then use a H2 for subsections
+## Then use a H2 for subsections
+```
 
 ## MD003 - Header style
 
@@ -103,34 +110,41 @@ Tags: headers
 
 Aliases: header-style
 
-Parameters: style (`:consistent`, `:atx`, `:atx_closed`, `:setext`, `:setext_with_atx`; default `:consistent`)
+Parameters: style (`:consistent`, `:atx`, `:atx_closed`, `:setext`,
+`:setext_with_atx`; default `:consistent`)
 
 This rule is triggered when different header styles (atx, setext, and 'closed'
 atx) are used in the same document:
 
-    # ATX style H1
+```markdown
+# ATX style H1
 
-    ## Closed ATX style H2 ##
+## Closed ATX style H2 ##
 
-    Setext style H1
-    ===============
+Setext style H1
+===============
+```
 
 Be consistent with the style of header used in a document:
 
-    # ATX style H1
+```markdown
+# ATX style H1
 
-    ## ATX style H2
+## ATX style H2
+```
 
 The setext_with_atx doc style allows atx-style headers of level 3 or more in
 documents with setext style headers:
 
-    Setext style H1
-    ===============
+```markdown
+Setext style H1
+===============
 
-    Setext style H2
-    ---------------
+Setext style H2
+---------------
 
-    ### ATX style H3
+### ATX style H3
+```
 
 Note: the configured header style can be a specific style to use (atx,
 atx_closed, setext, setext_with_atx), or simply require that the usage be
@@ -142,21 +156,26 @@ Tags: bullet, ul
 
 Aliases: ul-style
 
-Parameters: style (`:consistent`, `:asterisk`, `:plus`, `:dash`, `:sublist`; default `:consistent`)
+Parameters: style (`:consistent`, `:asterisk`, `:plus`, `:dash`, `:sublist`;
+default `:consistent`)
 
 This rule is triggered when the symbols used in the document for unordered
 list items do not match the configured unordered list style:
 
-    * Item 1
-    + Item 2
-    - Item 3
+```markdown
+* Item 1
++ Item 2
+- Item 3
+```
 
 To fix this issue, use the configured style for list items throughout the
 document:
 
-    * Item 1
-    * Item 2
-    * Item 3
+```markdown
+* Item 1
+* Item 2
+* Item 3
+```
 
 Note: the configured list style can be a specific symbol to use (asterisk,
 plus, dash), or simply require that the usage be consistent within the
@@ -165,31 +184,35 @@ document (consistent) or within a level (sublist).
 For sublist, each level must be consistent within a document, even if they
 are separate lists. So this is allowed:
 
-    * Item 1
-    * Item 2
-      - Item 2a
-        + Item 2a1
-      - Item 2b
-    * Item 3
+```markdown
+* Item 1
+* Item 2
+  - Item 2a
+    + Item 2a1
+  - Item 2b
+* Item 3
 
-    Other stuff
+Other stuff
 
-    * Item 1
-    * Item 2
+* Item 1
+* Item 2
+```
 
 But this is not allowed:
 
-    * Item 1
-    * Item 2
-      - Item 2a
-        + Item 2a1
-      - Item 2b
-    * Item 3
+```markdown
+* Item 1
+* Item 2
+  - Item 2a
+    + Item 2a1
+  - Item 2b
+* Item 3
 
-    Other stuff
+Other stuff
 
-    - Item 1
-    - Item 2
+- Item 1
+- Item 2
+```
 
 ## MD005 - Inconsistent indentation for list items at the same level
 
@@ -200,18 +223,22 @@ Aliases: list-indent
 This rule is triggered when list items are parsed as being at the same level,
 but don't have the same indentation:
 
-    * Item 1
-        * Nested Item 1
-        * Nested Item 2
-       * A misaligned item
+```markdown
+* Item 1
+    * Nested Item 1
+    * Nested Item 2
+   * A misaligned item
+```
 
 Usually this rule will be triggered because of a typo. Correct the indentation
 for the list to fix it:
 
-    * Item 1
-      * Nested Item 1
-      * Nested Item 2
-      * Nested Item 3
+```markdown
+* Item 1
+  * Nested Item 1
+  * Nested Item 2
+  * Nested Item 3
+```
 
 ## MD006 - Consider starting bulleted lists at the beginning of the line
 
@@ -222,24 +249,27 @@ Aliases: ul-start-left
 This rule is triggered when top level lists don't start at the beginning of a
 line:
 
-    Some text
+```markdown
+Some text
 
-      * List item
-      * List item
+  * List item
+  * List item
+```
 
 To fix, ensure that top level list items are not indented:
 
+```markdown
+Some test
 
-    Some test
-
-    * List item
-    * List item
+* List item
+* List item
+```
 
 Rationale: Starting lists at the beginning of the line means that nested list
 items can all be indented by the same amount when an editor's indent function
 or the tab key is used to indent. Starting a list 1 space in means that the
-indent of the first nested list is less than the indent of the second level (3
-characters if you use 4 space tabs, or 1 character if you use 2 space tabs).
+indent of the first nested list is less than the indent of the second level
+(3 characters if you use 4 space tabs, or 1 character if you use 2 space tabs).
 
 ## MD007 - Unordered list indentation
 
@@ -254,13 +284,17 @@ number of spaces (default: 2).
 
 Example:
 
-    * List item
-       * Nested list item indented by 3 spaces
+```markdown
+* List item
+   * Nested list item indented by 3 spaces
+```
 
 Corrected Example:
 
-    * List item
-      * Nested list item indented by 2 spaces
+```markdown
+* List item
+  * Nested list item indented by 2 spaces
+```
 
 Rationale (3 space indent): This matches the minimum possible indentation
 for _ordered_ lists (i.e Kramdown won't parse anything less than 3 spaces
@@ -272,8 +306,8 @@ This means if you want to set this to 2, you'll need to disable MD005.
 
 Rationale (4 space indent): Same indent as code blocks, simpler for editors to
 implement. See
-<https://cirosantilli.com/markdown-style-guide#spaces-before-list-marker> for more
-information.
+<https://cirosantilli.com/markdown-style-guide#spaces-before-list-marker>
+for more information.
 
 In addition, this is a compatibility issue with multi-markdown parsers, which
 require a 4 space indents. See
@@ -314,15 +348,19 @@ with spaces instead.
 
 Example:
 
-    Some text
+```markdown
+Some text
 
-    	* hard tab character used to indent the list item
+	* hard tab character used to indent the list item
+```
 
 Corrected example:
 
-    Some text
+```markdown
+Some text
 
-        * Spaces used to indent the list item instead
+    * Spaces used to indent the list item instead
+```
 
 You have the option to exclude this rule for code blocks. To do this, set the
 `ignore_code_blocks` parameter to true.
@@ -337,11 +375,15 @@ This rule is triggered when text that appears to be a link is encountered, but
 where the syntax appears to have been reversed (the `[]` and `()` are
 reversed):
 
-    (Incorrect link syntax)[http://www.example.com/]
+```markdown
+(Incorrect link syntax)[http://www.example.com/]
+```
 
 To fix this, swap the `[]` and `()` around:
 
-    [Correct link syntax](http://www.example.com/)
+```markdown
+[Correct link syntax](http://www.example.com/)
+```
 
 ## MD012 - Multiple consecutive blank lines
 
@@ -352,16 +394,20 @@ Aliases: no-multiple-blanks
 This rule is triggered when there are multiple consecutive blank lines in the
 document:
 
-    Some text here
+```markdown
+Some text here
 
 
-    Some more text here
+Some more text here
+```
 
 To fix this, delete the offending lines:
 
-    Some text here
+```markdown
+Some text here
 
-    Some more text here
+Some more text here
+```
 
 Note: this rule will not be triggered if there are multiple consecutive blank
 lines inside code blocks.
@@ -372,7 +418,9 @@ Tags: line_length
 
 Aliases: line-length
 
-Parameters: line_length, ignore_code_blocks, code_blocks, tables (number; default 80, boolean; default false, boolean; default true, boolean; default true)
+Parameters: line_length, ignore_code_blocks, code_blocks, tables (number;
+default 80, boolean; default false, boolean; default true, boolean; default
+true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line
@@ -401,26 +449,32 @@ Aliases: commands-show-output
 This rule is triggered when there are code blocks showing shell commands to be
 typed, and the shell commands are preceded by dollar signs ($):
 
-    $ ls
-    $ cat foo
-    $ less bar
+```markdown
+$ ls
+$ cat foo
+$ less bar
+```
 
 The dollar signs are unnecessary in the above situation, and should not be
 included:
 
-    ls
-    cat foo
-    less bar
+```markdown
+ls
+cat foo
+less bar
+```
 
 However, an exception is made when there is a need to distinguish between
 typed commands and command output, as in the following example:
 
-    $ ls
-    foo bar
-    $ cat foo
-    Hello world
-    $ cat bar
-    baz
+```markdown
+$ ls
+foo bar
+$ cat foo
+Hello world
+$ cat bar
+baz
+```
 
 Rationale: it is easier to copy and paste and less noisy if the dollar signs
 are omitted when they are not needed. See
@@ -436,16 +490,20 @@ Aliases: no-missing-space-atx
 This rule is triggered when spaces are missing after the hash characters
 in an atx style header:
 
-    #Header 1
+```markdown
+#Header 1
 
-    ##Header 2
+##Header 2
+```
 
 To fix this, separate the header text from the hash character by a single
 space:
 
-    # Header 1
+```markdown
+# Header 1
 
-    ## Header 2
+## Header 2
+```
 
 ## MD019 - Multiple spaces after hash on atx style header
 
@@ -456,16 +514,20 @@ Aliases: no-multiple-space-atx
 This rule is triggered when more than one space is used to separate the
 header text from the hash characters in an atx style header:
 
-    #  Header 1
+```markdown
+#  Header 1
 
-    ##  Header 2
+##  Header 2
+```
 
 To fix this, separate the header text from the hash character by a single
 space:
 
-    # Header 1
+```markdown
+# Header 1
 
-    ## Header 2
+## Header 2
+```
 
 ## MD020 - No space inside hashes on closed atx style header
 
@@ -476,16 +538,20 @@ Aliases: no-missing-space-closed-atx
 This rule is triggered when spaces are missing inside the hash characters
 in a closed atx style header:
 
-    #Header 1#
+```markdown
+#Header 1#
 
-    ##Header 2##
+##Header 2##
+```
 
 To fix this, separate the header text from the hash character by a single
 space:
 
-    # Header 1 #
+```markdown
+# Header 1 #
 
-    ## Header 2 ##
+## Header 2 ##
+```
 
 Note: this rule will fire if either side of the header is missing spaces.
 
@@ -498,16 +564,20 @@ Aliases: no-multiple-space-closed-atx
 This rule is triggered when more than one space is used to separate the
 header text from the hash characters in a closed atx style header:
 
-    #  Header 1  #
+```markdown
+#  Header 1  #
 
-    ##  Header 2  ##
+##  Header 2  ##
+```
 
 To fix this, separate the header text from the hash character by a single
 space:
 
-    # Header 1 #
+```markdown
+# Header 1 #
 
-    ## Header 2 ##
+## Header 2 ##
+```
 
 Note: this rule will fire if either side of the header contains multiple
 spaces.
@@ -521,22 +591,26 @@ Aliases: blanks-around-headers
 This rule is triggered when headers (any style) are either not preceded or not
 followed by a blank line:
 
-    # Header 1
-    Some text
+```markdown
+# Header 1
+Some text
 
-    Some more text
-    ## Header 2
+Some more text
+## Header 2
+```
 
 To fix this, ensure that all headers have a blank line both before and after
 (except where the header is at the beginning or end of the document):
 
-    # Header 1
+```markdown
+# Header 1
 
-    Some text
+Some text
 
-    Some more text
+Some more text
 
-    ## Header 2
+## Header 2
+```
 
 Rationale: Aside from aesthetic reasons, some parsers, including kramdown, will
 not parse headers that don't have a blank line before, and will parse them as
@@ -550,15 +624,19 @@ Aliases: header-start-left
 
 This rule is triggered when a header is indented by one or more spaces:
 
-    Some text
+```markdown
+Some text
 
-      # Indented header
+  # Indented header
+```
 
 To fix this, ensure that all headers start at the beginning of the line:
 
-    Some text
+```markdown
+Some text
 
-    # Header
+# Header
+```
 
 Rationale: Headers that don't start at the beginning of the line will not be
 parsed as headers, and will instead appear as regular text.
@@ -574,15 +652,19 @@ Parameters: allow_different_nesting (boolean; default false)
 This rule is triggered if there are multiple headers in the document that have
 the same text:
 
-    # Some text
+```markdown
+# Some text
 
-    ## Some text
+## Some text
+```
 
 To fix this, ensure that the content of each header is different:
 
-    # Some text
+```markdown
+# Some text
 
-    ## Some more text
+## Some more text
+```
 
 Rationale: Some markdown parses generate anchors for headers based on the
 header name, and having headers with the same content can cause problems with
@@ -591,17 +673,19 @@ this.
 If the parameter `allow_different_nesting` is set to `true`, header duplication
 under different nesting is allowed, like it usually happens in change logs:
 
-    # Change log
+```markdown
+# Change log
 
-    ## 2.0.0
+## 2.0.0
 
-    ### Bug fixes
+### Bug fixes
 
-    ### Features
+### Features
 
-    ## 1.0.0
+## 1.0.0
 
-    ### Bug fixes
+### Bug fixes
+```
 
 ## MD025 - Multiple top level headers in the same document
 
@@ -615,19 +699,23 @@ This rule is triggered when a top level header is in use (the first line of
 the file is a h1 header), and more than one h1 header is in use in the
 document:
 
-    # Top level header
+```markdown
+# Top level header
 
-    # Another top level header
+# Another top level header
+```
 
 To fix, structure your document so that there is a single h1 header that is
 the title for the document, and all later headers are h2 or lower level
 headers:
 
-    # Title
+```markdown
+# Title
 
-    ## Header
+## Header
 
-    ## Another header
+## Another header
+```
 
 Rationale: A top level header is a h1 on the first line of the file, and
 serves as the title for the document. If this convention is in use, then there
@@ -648,11 +736,15 @@ Parameters: punctuation (string; default ".,;:!?")
 This rule is triggered on any header that has a punctuation character as the
 last character in the line:
 
-    # This is a header.
+```markdown
+# This is a header.
+```
 
 To fix this, remove any trailing punctuation:
 
-    # This is a header
+```markdown
+# This is a header
+```
 
 Note: The punctuation parameter can be used to specify what characters class
 as punctuation at the end of the header. For example, you can set it to
@@ -668,13 +760,17 @@ Aliases: no-multiple-space-blockquote
 This rule is triggered when blockquotes have more than one space after the
 blockquote (`>`) symbol:
 
-    >  This is a block quote with bad indentation
-    >  there should only be one.
+```markdown
+>  This is a block quote with bad indentation
+>  there should only be one.
+```
 
 To fix, remove any extraneous space:
 
-    > This is a blockquote with correct
-    > indentation.
+```markdown
+> This is a blockquote with correct
+> indentation.
+```
 
 ## MD028 - Blank line inside blockquote
 
@@ -685,27 +781,33 @@ Aliases: no-blanks-blockquote
 This rule is triggered when two blockquote blocks are separated by nothing
 except for a blank line:
 
-    > This is a blockquote
-    > which is immediately followed by
+```markdown
+> This is a blockquote
+> which is immediately followed by
 
-    > this blockquote. Unfortunately
-    > In some parsers, these are treated as the same blockquote.
+> this blockquote. Unfortunately
+> In some parsers, these are treated as the same blockquote.
+```
 
 To fix this, ensure that any blockquotes that are right next to each other
 have some text in between:
 
-    > This is a blockquote.
+```markdown
+> This is a blockquote.
 
-    And Jimmy also said:
+And Jimmy also said:
 
-    > This too is a blockquote.
+> This too is a blockquote.
+```
 
 Alternatively, if they are supposed to be the same quote, then add the
 blockquote symbol at the beginning of the blank line:
 
-    > This is a blockquote.
-    >
-    > This is the same blockquote.
+```markdown
+> This is a blockquote.
+>
+> This is the same blockquote.
+```
 
 Rationale: Some markdown parsers will treat two blockquotes separated by one
 or more blank lines as the same blockquote, while others will treat them as
@@ -725,15 +827,19 @@ configured style, which defaults to 'one').
 
 Example valid list if the style is configured as 'one':
 
-    1. Do this.
-    1. Do that.
-    1. Done.
+```markdown
+1. Do this.
+1. Do that.
+1. Done.
+```
 
 Example valid list if the style is configured as 'ordered':
 
-    1. Do this.
-    2. Do that.
-    3. Done.
+```markdown
+1. Do this.
+2. Do that.
+3. Done.
+```
 
 ## MD030 - Spaces after list markers
 
@@ -749,17 +855,19 @@ This rule checks for the number of spaces between a list marker (e.g. '`-`',
 The number of spaces checked for depends on the document style in use, but the
 default is 1 space after any list marker:
 
-    * Foo
-    * Bar
-    * Baz
+```markdown
+* Foo
+* Bar
+* Baz
 
-    1. Foo
-    1. Bar
-    1. Baz
+1. Foo
+1. Bar
+1. Baz
 
-    1. Foo
-       * Bar
-    1. Baz
+1. Foo
+   * Bar
+1. Baz
+```
 
 A document style may change the number of spaces after unordered list items
 and ordered list items independently, as well as based on whether the content
@@ -773,25 +881,31 @@ the list fits within a single paragraph, but to use 2 or 3 spaces (for ordered
 and unordered lists respectively) if there are multiple paragraphs of content
 inside the list:
 
-    * Foo
-    * Bar
-    * Baz
+```markdown
+* Foo
+* Bar
+* Baz
+```
 
-    vs.
+vs.
 
-    *   Foo
+```markdown
+*   Foo
 
-        Second paragraph
+    Second paragraph
 
-    *   Bar
+*   Bar
+```
 
-    or
+or
 
-    1.  Foo
+```markdown
+1.  Foo
 
-        Second paragraph
+    Second paragraph
 
-    1.  Bar
+1.  Bar
+```
 
 To fix this, ensure the correct number of spaces are used after list marker
 for your selected document style.
@@ -842,26 +956,30 @@ Aliases: blanks-around-lists
 This rule is triggered when lists (of any kind) are either not preceded or not
 followed by a blank line:
 
-    Some text
-    * Some
-    * List
+```markdown
+Some text
+* Some
+* List
 
-    1. Some
-    2. List
-    Some text
+1. Some
+2. List
+Some text
+```
 
 To fix this, ensure that all lists have a blank line both before and after
 (except where the block is at the beginning or end of the document):
 
-    Some text
+```markdown
+Some text
 
-    * Some
-    * List
+* Some
+* List
 
-    1. Some
-    2. List
+1. Some
+2. List
 
-    Some text
+Some text
+```
 
 Rationale: Aside from aesthetic reasons, some parsers, including kramdown, will
 not parse lists that don't have blank lines before and after them.
@@ -869,11 +987,13 @@ not parse lists that don't have blank lines before and after them.
 Note: List items without hanging indents are a violation of this rule; list
 items with hanging indents are okay:
 
-    * This is
-    not okay
+```markdown
+* This is
+not okay
 
-    * This is
-      okay
+* This is
+  okay
+```
 
 ## MD033 - Inline HTML
 
@@ -883,11 +1003,15 @@ Aliases: no-inline-html
 
 This rule is triggered whenever raw HTML is used in a markdown document:
 
-    <h1>Inline HTML header</h1>
+```markdown
+<h1>Inline HTML header</h1>
+```
 
 To fix this, use 'pure' markdown instead of including raw HTML:
 
-    # Markdown header
+```markdown
+# Markdown header
+```
 
 Rationale: Raw HTML is allowed in markdown, but this rule is included for
 those who want their documents to only include "pure" markdown, or for those
@@ -902,11 +1026,15 @@ Aliases: no-bare-urls
 This rule is triggered whenever a URL is given that isn't surrounded by angle
 brackets:
 
-    For more information, see http://www.example.com/.
+```markdown
+For more information, see http://www.example.com/.
+```
 
 To fix this, add angle brackets around the URL:
 
-    For more information, see <http://www.example.com/>.
+```markdown
+For more information, see <http://www.example.com/>.
+```
 
 Rationale: Without angle brackets, the URL isn't converted into a link in many
 markdown parsers.
@@ -915,7 +1043,9 @@ Note: if you do want a bare URL without it being converted into a link,
 enclose it in a code block, otherwise in some markdown parsers it _will_ be
 converted:
 
-    `http://www.example.com`
+```markdown
+`http://www.example.com`
+```
 
 ## MD035 - Horizontal rule style
 
@@ -929,22 +1059,26 @@ horizontal rule; default `:consistent`)
 This rule is triggered when inconsistent styles of horizontal rules are used
 in the document:
 
-    ---
+```markdown
+---
 
-    - - -
+- - -
 
-    ***
+***
 
-    * * *
+* * *
 
-    ****
+****
+```
 
 To fix this, ensure any horizontal rules used in the document are consistent,
 or match the given style if the rule is so configured:
 
-    ---
+```markdown
+---
 
-    ---
+---
+```
 
 Note: by default, this rule is configured to just require that all horizontal
 rules in the document are the same, and will trigger if any of the horizontal
@@ -964,24 +1098,28 @@ Aliases: no-emphasis-as-header
 This check looks for instances where emphasized (i.e. bold or italic) text is
 used to separate sections, where a header should be used instead:
 
-    **My document**
+```markdown
+**My document**
 
-    Lorem ipsum dolor sit amet...
+Lorem ipsum dolor sit amet...
 
-    _Another section_
+_Another section_
 
-    Consectetur adipiscing elit, sed do eiusmod.
+Consectetur adipiscing elit, sed do eiusmod.
+```
 
 To fix this, use markdown headers instead of emphasized text to denote
 sections:
 
-    # My document
+```markdown
+# My document
 
-    Lorem ipsum dolor sit amet...
+Lorem ipsum dolor sit amet...
 
-    ## Another section
+## Another section
 
-    Consectetur adipiscing elit, sed do eiusmod.
+Consectetur adipiscing elit, sed do eiusmod.
+```
 
 Note: this rule looks for single line paragraphs that consist entirely of
 emphasized text.  It won't fire on emphasis used within regular text,
@@ -998,23 +1136,27 @@ Aliases: no-space-in-emphasis
 This rule is triggered when emphasis markers (bold, italic) are used, but they
 have spaces between the markers and the text:
 
-    Here is some ** bold ** text.
+```markdown
+Here is some ** bold ** text.
 
-    Here is some * italic * text.
+Here is some * italic * text.
 
-    Here is some more __ bold __ text.
+Here is some more __ bold __ text.
 
-    Here is some more _ italic _ text.
+Here is some more _ italic _ text.
+```
 
 To fix this, remove the spaces around the emphasis markers:
 
-    Here is some **bold** text.
+```markdown
+Here is some **bold** text.
 
-    Here is some *italic* text.
+Here is some *italic* text.
 
-    Here is some more __bold__ text.
+Here is some more __bold__ text.
 
-    Here is some more _italic_ text.
+Here is some more _italic_ text.
+```
 
 Rationale: Emphasis is only parsed as such when the asterisks/underscores
 aren't completely surrounded by spaces. This rule attempts to detect where
@@ -1030,15 +1172,19 @@ Aliases: no-space-in-code
 This rule is triggered on code span elements that have spaces right inside the
 backticks:
 
-    ` some text `
+```markdown
+` some text `
 
-    `some text `
+`some text `
 
-    ` some text`
+` some text`
+```
 
 To fix this, remove the spaces inside the codespan markers:
 
+```markdown
     `some text`
+```
 
 ## MD039 - Spaces inside link text
 
@@ -1048,11 +1194,15 @@ Aliases: no-space-in-links
 
 This rule is triggered on links that have spaces surrounding the link text:
 
-    [ a link ](http://www.example.com/)
+```markdown
+[ a link ](http://www.example.com/)
+```
 
 To fix this, remove the spaces surrounding the link text:
 
-    [a link](http://www.example.com/)
+```markdown
+[a link](http://www.example.com/)
+```
 
 ## MD040 - Fenced code blocks should have a language specified
 
@@ -1088,17 +1238,17 @@ Parameters: level (number; default 1)
 This rule is triggered when the first line in the file isn't a top level (h1)
 header:
 
-    ```
-    This is a file without a header
-    ```
+```markdown
+This is a file without a header
+```
 
 To fix this, add a header to the top of your file:
 
-    ```
-    # File with header
+```markdown
+# File with header
 
-    This is a file with a top level header
-    ```
+This is a file with a top level header
+```
 
 Note: The `level` parameter can be used to change the top level (ex: to h2) in
 cases where an h1 is added externally.
@@ -1139,7 +1289,8 @@ Tags: blank_lines
 
 Aliases: single-trailing-newline
 
-This rule is triggered when there is not a single newline character at the end of a file.
+This rule is triggered when there is not a single newline character at the end
+of a file.
 
 Example that triggers the rule:
 
@@ -1159,4 +1310,6 @@ This file ends with a newline.
 ```
 
 Rationale: Some programs have trouble with files that do not end with a newline.
-More information: <https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file>.
+More information:
+<https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file>.
+

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1183,7 +1183,7 @@ backticks:
 To fix this, remove the spaces inside the codespan markers:
 
 ```markdown
-    `some text`
+`some text`
 ```
 
 ## MD039 - Spaces inside link text


### PR DESCRIPTION
The linter (version 0.12.0) prompts 100 suggestions if running on the
previous commit of RULES.md.  Though not applicable in every instance
showcasing the potential improvement (rules MD031, 040, and 046 were
not touched at all), it was possible to lower this to 18, less than a
fifth of the former; mainly by

+ code fencing with an explicit label `markdown`
+ adjusting the indent to three spaces (unsorted list)
+ where possible, to constrain lines to to 80 characters per line (max)

Beside leading by example, this causes the display of RULES.md in
GitHub to engage a syntax highlighting similar to the one one may
encounter in an editor, too.

## Related Issues
Cf earlier suggest, https://github.com/markdownlint/markdownlint/issues/437

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios. Not applicable here.
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
