### PR TITLE
Add checkstyle format output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Checkstyle formatter/output
+
 ## [v0.12.0] (2022-10-17)
 
 ### Rules Added

--- a/lib/mdl/cli.rb
+++ b/lib/mdl/cli.rb
@@ -107,6 +107,12 @@ module MarkdownLint
            :description => 'JSON output',
            :boolean => true
 
+    option :checkstyle,
+           :short => '-C',
+           :long => '--checkstyle',
+           :description => 'Checkstyle output',
+           :boolean => true
+
     def run(argv = ARGV)
       parse_options(argv)
 

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '>= 11.2', '< 14'
   spec.add_development_dependency 'rubocop', '~> 1.28.1'
+  spec.add_development_dependency 'nokogiri', '~> 1.13.1'
 end

--- a/test/fixtures/checkstyle/no_errors.xml
+++ b/test/fixtures/checkstyle/no_errors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="10.5.0">
+<file name="(stdin)">
+</file>
+</checkstyle>


### PR DESCRIPTION
## Description
For some CI tools it is useful to output reports in checkstyle.

This PR adds the option `-C` (long format: `--checkstyle`) and the corresponding checkstyle output

## Related Issues
[Add checkstyle format](https://github.com/markdownlint/markdownlint/issues/440)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
