### PR TITLE
Remove David from MAINTAINERS

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,6 @@ have a discussion, and assuming there are no objections, you'll be added.
 * [Phil Dibowitz](https://github.com/jaymzh)
 * [Naomi Reeves](https://github.com/NaomiReeves)
 * [Bryan Wann](https://github.com/bwann)
-* [David Anson](https://github.com/DavidAnson)
 
 ## Past Maintainers
 


### PR DESCRIPTION
Per his comment in #310.

Signed-off-by: Phil Dibowitz <phil@ipom.com>


