### PR TITLE
replace http by https where deemed suitable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,20 +34,20 @@ process for contributions:
 1. Open an issue on the [project
    repository](https://github.com/markdownlint/markdownlint/issues), if
    appropriate
-2. If you're adding or making changes to rules, read the [Development
+1. If you're adding or making changes to rules, read the [Development
    docs](#local-development)
-3. Follow the [forking workflow](https://guides.github.com/activities/forking/)
+1. Follow the [forking workflow](https://guides.github.com/activities/forking/)
    steps:
    1. Fork the project ( <https://github.com/markdownlint/markdownlint/fork> )
-   2. Create your feature branch (`git checkout -b my-new-feature`)
-   3. Commit your changes (`git commit -am 'Add some feature'`)
-   4. Push to the branch (`git push origin my-new-feature`)
-4. Create a [GitHub Pull
+   1. Create your feature branch (`git checkout -b my-new-feature`)
+   1. Commit your changes (`git commit -am 'Add some feature'`)
+   1. Push to the branch (`git push origin my-new-feature`)
+1. Create a [GitHub Pull
    Request](https://help.github.com/articles/about-pull-requests/) for your
    change, following all [pull request
    requirements](#pull-request-requirements) and any instructions in the pull
    request template
-5. Participate in a [Code Review](#code-review-process) with the project
+1. Participate in a [Code Review](#code-review-process) with the project
    maintainers on the pull request
 
 ### Your First Code Contribution
@@ -90,7 +90,7 @@ this point is as follows:
 1. A review is required from at least one of the project maintainers. See the
    master maintainers document for Markdownlint project at
    <https://github.com/markdownlint/markdownlint/blob/master/MAINTAINERS.md>.
-2. Your change will be merged into the project's `master` branch, and all
+1. Your change will be merged into the project's `master` branch, and all
    [commits will be
    squashed](https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits)
    during the merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,20 +34,20 @@ process for contributions:
 1. Open an issue on the [project
    repository](https://github.com/markdownlint/markdownlint/issues), if
    appropriate
-1. If you're adding or making changes to rules, read the [Development
+2. If you're adding or making changes to rules, read the [Development
    docs](#local-development)
-1. Follow the [forking workflow](https://guides.github.com/activities/forking/)
+3. Follow the [forking workflow](https://guides.github.com/activities/forking/)
    steps:
-   1. Fork the project ( <http://github.com/markdownlint/markdownlint/fork> )
-   1. Create your feature branch (`git checkout -b my-new-feature`)
-   1. Commit your changes (`git commit -am 'Add some feature'`)
-   1. Push to the branch (`git push origin my-new-feature`)
-1. Create a [GitHub Pull
+   1. Fork the project ( <https://github.com/markdownlint/markdownlint/fork> )
+   2. Create your feature branch (`git checkout -b my-new-feature`)
+   3. Commit your changes (`git commit -am 'Add some feature'`)
+   4. Push to the branch (`git push origin my-new-feature`)
+4. Create a [GitHub Pull
    Request](https://help.github.com/articles/about-pull-requests/) for your
    change, following all [pull request
    requirements](#pull-request-requirements) and any instructions in the pull
    request template
-1. Participate in a [Code Review](#code-review-process) with the project
+5. Participate in a [Code Review](#code-review-process) with the project
    maintainers on the pull request
 
 ### Your First Code Contribution
@@ -90,7 +90,7 @@ this point is as follows:
 1. A review is required from at least one of the project maintainers. See the
    master maintainers document for Markdownlint project at
    <https://github.com/markdownlint/markdownlint/blob/master/MAINTAINERS.md>.
-1. Your change will be merged into the project's `master` branch, and all
+2. Your change will be merged into the project's `master` branch, and all
    [commits will be
    squashed](https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits)
    during the merge.
@@ -104,7 +104,7 @@ Cycles](#release-cycles).
 We release Markdownlint as a gem to [Rubygems](https://rubygems.org/gems/mdl)
 and maintain a [Dockerfile](https://hub.docker.com/r/mivok/markdownlint)
 
-Markdownlint follows the [Semantic Versioning](http://semver.org/) standard.
+Markdownlint follows the [Semantic Versioning](https://semver.org/) standard.
 Our standard version numbers look like `X.Y.Z` and translates to:
 
 * `X` is a major release: has changes that may be incompatible with prior major

--- a/docs/rolling_a_release.md
+++ b/docs/rolling_a_release.md
@@ -1,7 +1,7 @@
 # Rolling a new release
 
 Bump the version. Markdownlint uses semantic versioning. From
-<http://semver.org/>:
+<https://semver.org/>:
 
 * Major version for backwards-incompatible changes
 * Minor version for functionality added in a backwards-compatible manner

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -33,7 +33,7 @@ end
 
 rule 'MD003', 'Header style' do
   # Header styles are things like ### and adding underscores
-  # See http://daringfireball.net/projects/markdown/syntax#header
+  # See https://daringfireball.net/projects/markdown/syntax#header
   tags :headers
   aliases 'header-style'
   # :style can be one of :consistent, :atx, :atx_closed, :setext

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email = ['mark@mivok.net']
   spec.summary = 'Markdown lint tool'
   spec.description = 'Style checker/lint tool for markdown files'
-  spec.homepage = 'http://github.com/markdownlint/markdownlint'
+  spec.homepage = 'https://github.com/markdownlint/markdownlint'
   spec.license = 'MIT'
   spec.metadata['rubygems_mfa_required'] = 'true'
 


### PR DESCRIPTION
## Description
Separate from this git monitored repository, `markdownlint`
entered Linux Debian as package `ruby-mdl`.  During this work,
some files relevant to the packaging used outdated http addresses
now replaced by the https protocol now in place.
    
To preserve the functionality of markdownlint, there still are
seven untouched markdown files with examples and addresses of
the elder format 'http://'.  These include file `/docs/RULES.md`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
