### PR TITLE
replace http by https where deemed suitable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ process for contributions:
    docs](#local-development)
 1. Follow the [forking workflow](https://guides.github.com/activities/forking/)
    steps:
-   1. Fork the project ( <http://github.com/markdownlint/markdownlint/fork> )
+   1. Fork the project ( <https://github.com/markdownlint/markdownlint/fork> )
    1. Create your feature branch (`git checkout -b my-new-feature`)
    1. Commit your changes (`git commit -am 'Add some feature'`)
    1. Push to the branch (`git push origin my-new-feature`)
@@ -104,7 +104,7 @@ Cycles](#release-cycles).
 We release Markdownlint as a gem to [Rubygems](https://rubygems.org/gems/mdl)
 and maintain a [Dockerfile](https://hub.docker.com/r/mivok/markdownlint)
 
-Markdownlint follows the [Semantic Versioning](http://semver.org/) standard.
+Markdownlint follows the [Semantic Versioning](https://semver.org/) standard.
 Our standard version numbers look like `X.Y.Z` and translates to:
 
 * `X` is a major release: has changes that may be incompatible with prior major

--- a/docs/rolling_a_release.md
+++ b/docs/rolling_a_release.md
@@ -1,7 +1,7 @@
 # Rolling a new release
 
 Bump the version. Markdownlint uses semantic versioning. From
-<http://semver.org/>:
+<https://semver.org/>:
 
 * Major version for backwards-incompatible changes
 * Minor version for functionality added in a backwards-compatible manner

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -33,7 +33,7 @@ end
 
 rule 'MD003', 'Header style' do
   # Header styles are things like ### and adding underscores
-  # See http://daringfireball.net/projects/markdown/syntax#header
+  # See https://daringfireball.net/projects/markdown/syntax#header
   tags :headers
   aliases 'header-style'
   # :style can be one of :consistent, :atx, :atx_closed, :setext

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email = ['mark@mivok.net']
   spec.summary = 'Markdown lint tool'
   spec.description = 'Style checker/lint tool for markdown files'
-  spec.homepage = 'http://github.com/markdownlint/markdownlint'
+  spec.homepage = 'https://github.com/markdownlint/markdownlint'
   spec.license = 'MIT'
   spec.metadata['rubygems_mfa_required'] = 'true'
 


### PR DESCRIPTION
Separate from this git monitored repository, `markdownlint`
entered Linux Debian as package `ruby-mdl`.  During this work,
some files relevant to the packaging used outdated http addresses
now replaced by the https protocol now in place.

Each edit was programmatic in the pattern of

```
sed -i "s/http\:/https\:/g" CONTRIBUTING.md
```

To preserve the functionality of markdownlint, there still are
seven untouched markdown files with examples and addresses of
the elder format 'http://'.  These include file `/docs/RULES.md`
    
Signed-off-by: Norwid Behrnd <nbehrnd@yahoo.com>

## Types of changes
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
