### PR TITLE
add signature requirement to the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ process for contributions:
    1. Fork the project ( <http://github.com/markdownlint/markdownlint/fork> )
    1. Create your feature branch (`git checkout -b my-new-feature`)
    1. Commit your changes (`git commit -am 'Add some feature'`)
+   1. Sign your changes (`git commit --ammend -s`)
    1. Push to the branch (`git push origin my-new-feature`)
 1. Create a [GitHub Pull
    Request](https://help.github.com/articles/about-pull-requests/) for your


### PR DESCRIPTION
If the project agreed to sign-off the commits, the documentation better mentions this explicitly.

Signed-off-by: Norwid Behrnd <nbehrnd@yahoo.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
