### PR TITLE
Allow exactly 2 trailing spaces by default as per MD009 (#195)

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -320,7 +320,7 @@ Tags: whitespace
 
 Aliases: no-trailing-spaces
 
-Parameters: br_spaces (number; default: 0)
+Parameters: br_spaces (number; default: 2)
 
 This rule is triggered on any lines that end with whitespace. To fix this,
 find the line that is triggered and remove any trailing spaces from the end.
@@ -332,7 +332,7 @@ example, set br_spaces to 2 to allow exactly 2 spaces at the end of a line.
 Note: you have to set br_spaces to 2 or higher for this exception to take
 effect - you can't insert a br element with just a single trailing space, so
 if you set br_spaces to 1, the exception will be disabled, just as if it was
-set to the default of 0.
+set to 0.
 
 ## MD010 - Hard tabs
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -161,7 +161,7 @@ end
 rule 'MD009', 'Trailing spaces' do
   tags :whitespace
   aliases 'no-trailing-spaces'
-  params :br_spaces => 0
+  params :br_spaces => 2
   check do |doc|
     errors = doc.matching_lines(/\s$/)
     if params[:br_spaces] > 1


### PR DESCRIPTION
## Description
The br_spaces parameter allows an exception to this rule for a specific number of trailing spaces, typically used to insert an explicit line break. The default value allows 2 spaces to indicate a hard break (<br> element).

This default is more sensible in line with real world usage where two spaces are rendered as hard break and not considered to be a format issue.  Changing the default from 0 to 2 will not create undesired surprises downstream as linting and CI of currently valid documents won't be altered as the new default is more relaxed in that regard.

The new default of 2 br_spaces is also in line with other tools, linter and renderer.

## Related Issues
Allow exactly 2 trailing spaces by default as per MD009 (#195)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
