### PR TITLE
[MD055, MD056, MD057] Features for validating table format

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -41,7 +41,7 @@
    * [MD047 - File should end with a single newline character](#md047---file-should-end-with-a-single-newline-character)
    * [MD055 - Table row doesn't begin/end with pipes](#md055---table-row-doesnt-begin-end-with-pipes)
    * [MD056 - Table has inconsistent number of columns](#md056---table-has-inconsistent-number-of-columns)
-   * [MD057 - Table has missing or invalid header seperation (second row)](#md057---table-has-missing-or-invalid-header-seperation)
+   * [MD057 - Table has missing or invalid header separation (second row)](#md057---table-has-missing-or-invalid-header-separation)
 
 # Rules
 
@@ -1378,15 +1378,15 @@ the extra columns or adding missing ones. One solution can be
 Rationale: If the table rows do not have the same number of columns, there may be 
 redundant or missing data.
 
-## MD057 - Table has missing or invalid header seperation (second row)
+## MD057 - Table has missing or invalid header separation (second row)
 
 Tags: tables
 
 Aliases: table-invalid-second-row
 
-This rule is triggered when the header seperation (second row in the table)
+This rule is triggered when the header separation (second row in the table)
 is not well-formed. It should at least contain three dashes, i.e. '---' and 
-might have colons, i.e. ':' at the start or end of the seperation string:
+might have colons, i.e. ':' at the start or end of the separation string:
 
 ```markdown
 | Heading 1 | Heading 2 | Heading 3 | Heading 4 |

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -39,6 +39,9 @@
    * [MD041 - First line in file should be a top level header](#md041---first-line-in-file-should-be-a-top-level-header)
    * [MD046 - Code block style](#md046---code-block-style)
    * [MD047 - File should end with a single newline character](#md047---file-should-end-with-a-single-newline-character)
+   * [MD055 - Table row doesn't begin/end with pipes](#md055---table-row-doesnt-begin-end-with-pipes)
+   * [MD056 - Table has inconsistent number of columns](#md056---table-has-inconsistent-number-of-columns)
+   * [MD057 - Table has missing or invalid header seperation (second row)](#md057---table-has-missing-or-invalid-header-seperation)
 
 # Rules
 
@@ -1320,3 +1323,83 @@ This file ends with a newline.
 Rationale: Some programs have trouble with files that do not end with a newline.
 More information:
 <https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file>.
+
+## MD055 - Table row doesn't begin/end with pipes
+
+Tags: tables
+
+Aliases: table-rows-start-and-end-with-pipes
+
+This rule is triggered when a table row does not start or end with pipe, '|',
+character:
+
+```markdown
+| Heading 1 | Heading 2 |
+   | ------- | ---------
+    Data    |    Data   |
+```
+
+To fix this, add or align pipe characters to the beginning or end of the row.
+
+```markdown
+| Heading 1 | Heading 2 |
+| ------- | ---------|
+|   Data    |    Data   |
+```
+
+Rationale: If the table rows are not well-formed, not all renderers 
+may show it correctly.
+
+## MD056 - Table has inconsistent number of columns
+
+Tags: tables
+
+Aliases: inconsistent-columns-in-table
+
+This rule is triggered when the number of columns in table rows do not match:
+
+```markdown
+| Heading 1 | Heading 2 |
+| :--------:| ---------:| ----- |
+|Data|Data|Data|
+|Data|Data|
+```
+
+To fix this, match your number of columns with the header by either deleting
+the extra columns or adding missing ones. One solution can be
+
+```markdown
+| Heading 1 | Heading 2 |
+| :--------:| ---------:|
+|Data|Data|
+|Data|Data|
+```
+
+Rationale: If the table rows do not have the same number of columns, there may be 
+redundant or missing data.
+
+## MD057 - Table has missing or invalid header seperation (second row)
+
+Tags: tables
+
+Aliases: table-invalid-second-row
+
+This rule is triggered when the header seperation (second row in the table)
+is not well-formed. It should at least contain three dashes, i.e. '---' and 
+might have colons, i.e. ':' at the start or end of the seperation string:
+
+```markdown
+| Heading 1 | Heading 2 | Heading 3 | Heading 4 |
+| -- | ::---:: | ---a--- |:----
+|Data|Data|Data|Data|
+```
+
+To fix this, make sure the second row of the table conforms with the above rules
+
+```markdown
+| Heading 1 | Heading 2 | Heading 3 | Heading 4 |
+| --- | :---: | ------ |:----|
+|Data|Data|Data|Data|
+```
+
+Rationale: If the table is not well-formed, not all renderers may show it correctly.

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -797,7 +797,7 @@ rule 'MD047', 'File should end with a single newline character' do
   end
 end
 
-rule 'MD048', 'Tables should be well-formed' do
+rule 'MD055', 'Tables should be well-formed' do
   tags :tables
   aliases 'table-format-validation'
   check do |doc|

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -797,84 +797,91 @@ rule 'MD047', 'File should end with a single newline character' do
   end
 end
 
-rule 'MD055', 'Tables should be well-formed' do
+rule 'MD055', 'Table row doesn\'t begin/end with pipes' do
   tags :tables
-  aliases 'table-format-validation'
+  aliases 'table-rows-start-and-end-with-pipes'
   check do |doc|
     error_lines = []
     tables = doc.find_type_elements(:table)
     lines = doc.lines
-    num_lines = lines.length
 
     tables.each do |table|
-      loc = table.options[:location]-1
-      header = lines[loc]
+      table_pos = table.options[:location] - 1
+      table_rows = get_table_rows(lines, table_pos)
 
-      if header[0] != '|' || header[-1] != '|' || header.length == 1
-        # Tables should start and end with '|'
-        error_lines << (loc+1)
-      end
-
-      headings = header.strip().split('|').select{ |x| x.length > 0 }
-      num_headings = headings.length
-
-      if loc+1 < num_lines
-        # Second row should be in the form | ---- | ---- |
-        second_row = lines[loc+1]
-        columns = second_row.strip().split('|').select{ |x| x.length > 0 }
-        if num_headings != columns.length
-          # Number of headings do not match with the second row
-          error_lines << (loc+2)
+      table_rows.each_with_index do |line, index|
+        if line.length == 1 || line[0] != '|' || line[-1] != '|'
+          error_lines << (table_pos + index + 1)
         end
-        
-        # This pattern matches if
-        #   1) The row starts and stops with | characters
-        #   2) Only consists of characters '|', '-', ':' and whitespace
-        #   3) Each section between the seperators (i.e. '|')
-        #      a) has at least three consecutive dashes
-        #      b) can have whitespace at the beginning or the end
-        #      c) can have colon before and/or after the dashes (for alignment purposes)
-        #   Some examples:
-        #       |-----|----|-------|      --> matches
-        #       |:---:|:---|-------|      --> matches
-        #       |  :------:  | ----|      --> matches
-        #       | - - - | - - - |         --> does NOT match
-        #       |::---|                   --> does NOT match
-        #       |----:|:--|----|          --> does NOT match
-        pattern = /^(\|\s*:?-{3,}:?\s*)+\|$/
-        unless second_row.match(pattern)
-          # Second row is not in the form described by the pattern
-          error_lines << (loc+2)
-        end
-
-        # Check next lines until the end of the table
-        line_num = loc+2
-        while second_row.strip() != '' && line_num < num_lines
-          line = lines[line_num]
-          stripped_line = line.strip()
-
-          # If the line has '|' character, it's "possibly" a table row
-          # because the previous line was also a table row
-          if line.include?('|')
-            columns = stripped_line.split('|').select{ |x| x.length > 0 }
-            if (line[0] != '|' || line[-1] != '|') || columns.length != num_headings
-              # the line does not start and stop with '|' OR 
-              # number of columns do not match number of headings
-              error_lines << (line_num+1)
-            end
-          else
-            # Table ends
-            break
-          end
-
-          line_num += 1
-        end
-      else
-        # Table without a second row 
-        error_lines << (loc+1)
       end
     end
 
-    error_lines.uniq.sort
+    error_lines
+  end
+end
+
+rule 'MD056', 'Table has inconsistent number of columns' do
+  tags :tables
+  aliases 'inconsistent-columns-in-table'
+  check do |doc|
+    error_lines = []
+    tables = doc.find_type_elements(:table)
+    lines = doc.lines
+
+    tables.each do |table|
+      table_pos = table.options[:location] - 1
+      table_rows = get_table_rows(lines, table_pos)
+
+      num_headings = number_of_columns_in_a_table_row(lines[table_pos])
+
+      table_rows.each_with_index do |line, index|
+        if number_of_columns_in_a_table_row(line) != num_headings
+          error_lines << (table_pos + index + 1)
+        end
+      end
+    end
+
+    error_lines
+  end
+end
+
+rule 'MD057', 'Table has missing or invalid header separation (second row)' do
+  tags :tables
+  aliases 'table-invalid-second-row'
+  check do |doc|
+    error_lines = []
+    tables = doc.find_type_elements(:table)
+    lines = doc.lines
+
+    tables.each do |table|
+      second_row = ''
+
+      # line number of table start (1-indexed)
+      # which is equal to second row's index (0-indexed)
+      line_num = table.options[:location]
+      second_row = lines[line_num] if line_num < lines.length
+
+      # This pattern matches if
+      #   1) The row starts and stops with | characters
+      #   2) Only consists of characters '|', '-', ':' and whitespace
+      #   3) Each section between the seperators (i.e. '|')
+      #      a) has at least three consecutive dashes
+      #      b) can have whitespace at the beginning or the end
+      #      c) can have colon before and/or after dashes (for alignment)
+      #   Some examples:
+      #       |-----|----|-------|      --> matches
+      #       |:---:|:---|-------|      --> matches
+      #       |  :------:  | ----|      --> matches
+      #       | - - - | - - - |         --> does NOT match
+      #       |::---|                   --> does NOT match
+      #       |----:|:--|----|          --> does NOT match
+      pattern = /^(\|\s*:?-{3,}:?\s*)+\|$/
+      unless second_row.match(pattern)
+        # Second row is not in the form described by the pattern
+        error_lines << (line_num + 1)
+      end
+    end
+
+    error_lines
   end
 end

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -810,7 +810,7 @@ rule 'MD055', 'Table row doesn\'t begin/end with pipes' do
       table_rows = get_table_rows(lines, table_pos)
 
       table_rows.each_with_index do |line, index|
-        if line.length == 1 || line[0] != '|' || line[-1] != '|'
+        if line.length < 2 || line[0] != '|' || line[-1] != '|'
           error_lines << (table_pos + index + 1)
         end
       end
@@ -864,7 +864,7 @@ rule 'MD057', 'Table has missing or invalid header separation (second row)' do
       # This pattern matches if
       #   1) The row starts and stops with | characters
       #   2) Only consists of characters '|', '-', ':' and whitespace
-      #   3) Each section between the seperators (i.e. '|')
+      #   3) Each section between the separators (i.e. '|')
       #      a) has at least three consecutive dashes
       #      b) can have whitespace at the beginning or the end
       #      c) can have colon before and/or after dashes (for alignment)

--- a/lib/mdl/ruleset.rb
+++ b/lib/mdl/ruleset.rb
@@ -99,7 +99,7 @@ module MarkdownLint
         #
         # it is possibly a table row
         unless line.include?('|') && !line.start_with?('    ') &&
-            !line.strip.start_with?('```')
+               !line.strip.start_with?('```')
           break
         end
 

--- a/lib/mdl/ruleset.rb
+++ b/lib/mdl/ruleset.rb
@@ -98,8 +98,8 @@ module MarkdownLint
         #     b) < 4 spaces and ``` right after
         #
         # it is possibly a table row
-        unless !line.start_with?('    ') && !line.strip.start_with?('```') \
-            && line.include?('|')
+        unless line.include?('|') && !line.start_with?('    ') &&
+            !line.strip.start_with?('```')
           break
         end
 

--- a/test/rule_tests/table_format_validation.md
+++ b/test/rule_tests/table_format_validation.md
@@ -23,6 +23,10 @@ If there is a non-empty line just above the table, it won't be detected
 
 Funnily, above table is not picked up by Kramdown. So, its errors are not detected.
 
+|table not detected|
+```codeblock
+```
+
 ## Good Tables
 
 | A Good Table | A Good Table |
@@ -66,13 +70,13 @@ Funnily, above table is not picked up by Kramdown. So, its errors are not detect
 | Data | Row shouldn't end with space | 
 
 | Rows shouldn't start or end with space | Column |
-    | --- | --- |
-    | Data | Data |
+   | --- | --- |
+   | Data | Data |
 
-{MD055:64}
-{MD055:66}
-{MD055:69}
+{MD055:68}
 {MD055:70}
+{MD055:73}{MD057:73}
+{MD055:74}
 
 ## Table rows have wrong number of columns
 
@@ -89,9 +93,9 @@ Funnily, above table is not picked up by Kramdown. So, its errors are not detect
 |-----|-----|
 |row|row|row|row|row|
 
-{MD055:81}
-{MD055:86}
-{MD055:90}
+{MD056:85}
+{MD056:90}
+{MD056:94}
 
 ## Rows do not start or end with pipe character
 
@@ -119,12 +123,12 @@ row|row|
 |-----|-----|
 row|row
 
-{MD055:98}
 {MD055:102}
-{MD055:107}
-{MD055:112}
+{MD055:106}
+{MD055:111}{MD057:111}
 {MD055:116}
 {MD055:120}
+{MD055:124}
 
 ## Second row has less than three dashes in some column
 
@@ -140,9 +144,9 @@ row|row
 | ------ | | ------ |
 | Col 1 | Col 2 | Col 3 |
 
-{MD055:132}
-{MD055:136}
-{MD055:140}
+{MD057:136}
+{MD057:140}
+{MD057:144}
 
 ## Second row has wrong use of colons
 
@@ -154,8 +158,8 @@ row|row
 | ------ | ----:: | ------ |
 | Col 1 | Col 2 | Col 3 |
 
-{MD055:150}
-{MD055:154}
+{MD057:154}
+{MD057:158}
 
 ## Second row has invalid characters
 
@@ -163,7 +167,7 @@ row|row
 | ---aa--- | ----bb----|
 | row 1 | row 1 |
 
-{MD055:163}
+{MD057:167}
 
 ## Second row has space inbetween dashes and/or colons
 
@@ -175,8 +179,8 @@ row|row
 | ------ | : ---- : | ------ |
 | Col 1 | Col 2 | Col 3 |
 
-{MD055:171}
-{MD055:175}
+{MD057:175}
+{MD057:179}
 
 ## Edge Cases
 
@@ -195,12 +199,12 @@ This weird line is also a table detected by Kramdown |
 
 |||||
 
-{MD055:188}
-{MD055:192}
-{MD055:193}
-{MD055:194}
-{MD055:195}
-{MD055:197}
+{MD057:192}
+{MD055:196}
+{MD057:197}
+{MD055:198}
+{MD057:199}
+{MD057:201}
 
 ## Table with only heading
 
@@ -208,8 +212,8 @@ This weird line is also a table detected by Kramdown |
 
 |two column heading|the next line is reported|
 
-{MD055:208}
-{MD055:210}
+{MD057:212}
+{MD057:214}
 
 ## Not a table
 
@@ -226,3 +230,18 @@ This weird line is also a table detected by Kramdown |
 ## Table inside heading
 
 ### |This is not a table|
+
+## No second row exists because it's a code block
+
+|table|
+    |--------|
+|this line is in code block|another column won't be a problem|
+
+|table|
+```|------|```
+|this line isn't in code block, but it's not detected as table as well|col|
+|----|not detected|
+|data|not detected|
+
+{MD057:237}
+{MD057:241}

--- a/test/rule_tests/table_format_validation.md
+++ b/test/rule_tests/table_format_validation.md
@@ -69,10 +69,10 @@ Funnily, above table is not picked up by Kramdown. So, its errors are not detect
     | --- | --- |
     | Data | Data |
 
-{MD048:64}
-{MD048:66}
-{MD048:69}
-{MD048:70}
+{MD055:64}
+{MD055:66}
+{MD055:69}
+{MD055:70}
 
 ## Table rows have wrong number of columns
 
@@ -89,9 +89,9 @@ Funnily, above table is not picked up by Kramdown. So, its errors are not detect
 |-----|-----|
 |row|row|row|row|row|
 
-{MD048:81}
-{MD048:86}
-{MD048:90}
+{MD055:81}
+{MD055:86}
+{MD055:90}
 
 ## Rows do not start or end with pipe character
 
@@ -119,12 +119,12 @@ row|row|
 |-----|-----|
 row|row
 
-{MD048:98}
-{MD048:102}
-{MD048:107}
-{MD048:112}
-{MD048:116}
-{MD048:120}
+{MD055:98}
+{MD055:102}
+{MD055:107}
+{MD055:112}
+{MD055:116}
+{MD055:120}
 
 ## Second row has less than three dashes in some column
 
@@ -140,9 +140,9 @@ row|row
 | ------ | | ------ |
 | Col 1 | Col 2 | Col 3 |
 
-{MD048:132}
-{MD048:136}
-{MD048:140}
+{MD055:132}
+{MD055:136}
+{MD055:140}
 
 ## Second row has wrong use of colons
 
@@ -154,8 +154,8 @@ row|row
 | ------ | ----:: | ------ |
 | Col 1 | Col 2 | Col 3 |
 
-{MD048:150}
-{MD048:154}
+{MD055:150}
+{MD055:154}
 
 ## Second row has invalid characters
 
@@ -163,7 +163,7 @@ row|row
 | ---aa--- | ----bb----|
 | row 1 | row 1 |
 
-{MD048:163}
+{MD055:163}
 
 ## Second row has space inbetween dashes and/or colons
 
@@ -175,8 +175,8 @@ row|row
 | ------ | : ---- : | ------ |
 | Col 1 | Col 2 | Col 3 |
 
-{MD048:171}
-{MD048:175}
+{MD055:171}
+{MD055:175}
 
 ## Edge Cases
 
@@ -195,12 +195,12 @@ This weird line is also a table detected by Kramdown |
 
 |||||
 
-{MD048:188}
-{MD048:192}
-{MD048:193}
-{MD048:194}
-{MD048:195}
-{MD048:197}
+{MD055:188}
+{MD055:192}
+{MD055:193}
+{MD055:194}
+{MD055:195}
+{MD055:197}
 
 ## Table with only heading
 
@@ -208,8 +208,8 @@ This weird line is also a table detected by Kramdown |
 
 |two column heading|the next line is reported|
 
-{MD048:208}
-{MD048:210}
+{MD055:208}
+{MD055:210}
 
 ## Not a table
 

--- a/test/rule_tests/table_format_validation.md
+++ b/test/rule_tests/table_format_validation.md
@@ -1,0 +1,228 @@
+# Table Format Validation
+
+## Undetected tables (Kramdown Limitations)
+
+| This empty but correctly formatted table won't be detected by Kramdown |
+| ------------ |
+
+| This empty and wrongly formatted table won't be detected at all |
+| -- |
+
+If there is a non-empty line just above the table, it won't be detected
+| Heading 1 | Heading 2 | Heading 3 |
+| --------- | ::::::::::| :-------- |
+| Data      | Data      | Data      |
+
+.
+|my undetected table|my undetected table because of the dot above|
+|----|-----::::|
+|row|row|
+
+|one column heading|
+| ::----------------:: |
+
+Funnily, above table is not picked up by Kramdown. So, its errors are not detected.
+
+## Good Tables
+
+| A Good Table | A Good Table |
+| :------------ | :------------: |
+|  Col 1    | Col 2 |
+
+| A Good Table | A Good Table |
+| :---: | ------------: |
+|  Col 1    | Col 2 |
+
+| A Good Table | Col 2 |
+|  :------:  | ----|
+| Row 1, Col 1 | Row 1, Col 2|
+
+| At least three dashes in second row |
+| --- |
+| Data |
+
+| Heading 1 | Heading 2 | Heading 3 |
+| --------- | :--------:| :-------- |
+| Data      | Data      | Data      |
+| Data      | Data      | Data      |
+| Data      | Data      | Data      |
+| Data      | Data      | Data      |
+| Data      | Data      | Data      |
+| Data      | Data      | Data      |
+| Data      | Data      | Data      |
+
+| Second row is correct | Col 2 |
+|  :------:  | ----|
+| Row 1, Col 1 | Row 1, Col 2|
+
+| Good Table |
+|------------|
+|    Data    |
+
+## Table rows start or end with space
+
+ | Header shouldn't start with space | Column |
+| --- | --- |
+| Data | Row shouldn't end with space | 
+
+| Rows shouldn't start or end with space | Column |
+    | --- | --- |
+    | Data | Data |
+
+{MD048:64}
+{MD048:66}
+{MD048:69}
+{MD048:70}
+
+## Table rows have wrong number of columns
+
+| Table with row 1 having wrong number of columns |
+|:--------:|
+| Col 1 | Col 2 |
+
+| Table row entry 2 has wrong number of columns | Header Col |
+|:--------:|-----|
+| Col 1 | Col 2 |
+| Col 1 | Col 2| Col 3|
+
+|table|table|
+|-----|-----|
+|row|row|row|row|row|
+
+{MD048:81}
+{MD048:86}
+{MD048:90}
+
+## Rows do not start or end with pipe character
+
+Heading does not start with pipe | Column |
+|-----|-----|
+|Data|Data|
+
+|Heading does not end with pipe | Column
+|-----|-----|
+|Data|Data|
+
+|Second row does not have pipes at the start and the end  | Column |
+-----|-----
+|Data|Data|
+
+|table2|table2|
+|-----|-----|
+|row|row
+
+|table2|table2|
+|-----|-----|
+row|row|
+
+|table2|table2|
+|-----|-----|
+row|row
+
+{MD048:98}
+{MD048:102}
+{MD048:107}
+{MD048:112}
+{MD048:116}
+{MD048:120}
+
+## Second row has less than three dashes in some column
+
+| Second row columns must have at least three dashes | Header Col | Header Col|
+| ------ | -- | ------ |
+| Col 1 | Col 2 | Col 3 |
+
+| Second row columns must have at least three dashes | Header Col | Header Col|
+| ------ | :--: | ------ |
+| Col 1 | Col 2 | Col 3 |
+
+| Second row columns must have at least three dashes | Header Col | Header Col|
+| ------ | | ------ |
+| Col 1 | Col 2 | Col 3 |
+
+{MD048:132}
+{MD048:136}
+{MD048:140}
+
+## Second row has wrong use of colons
+
+| Heading 1 | Heading 2 | Heading 3 |
+| --------- | :::::---:::::| :-------- |
+| Data      | Data      | Data      |
+
+| Second row column two has wrong format | Header Col | Header Col|
+| ------ | ----:: | ------ |
+| Col 1 | Col 2 | Col 3 |
+
+{MD048:150}
+{MD048:154}
+
+## Second row has invalid characters
+
+|   tab    |    tab    |
+| ---aa--- | ----bb----|
+| row 1 | row 1 |
+
+{MD048:163}
+
+## Second row has space inbetween dashes and/or colons
+
+| Second row column one has wrong format | Header Col | Header Col|
+| -- - - -- | :----: | ------ |
+| Col 1 | Col 2 | Col 3 |
+
+| Second row column one has wrong format | Header Col | Header Col|
+| ------ | : ---- : | ------ |
+| Col 1 | Col 2 | Col 3 |
+
+{MD048:171}
+{MD048:175}
+
+## Edge Cases
+
+Interestingly, the following empty table is picked up by Kramdown,
+and the next line is reported by the script because it does not
+conform to the rules of the second row
+
+||
+
+Another wrong table, but it's get detected by Kramdown. This time,
+both this line and the next line is reported.
+
+|
+
+This weird line is also a table detected by Kramdown |
+
+|||||
+
+{MD048:188}
+{MD048:192}
+{MD048:193}
+{MD048:194}
+{MD048:195}
+{MD048:197}
+
+## Table with only heading
+
+|one column heading, second row does not exist|
+
+|two column heading|the next line is reported|
+
+{MD048:208}
+{MD048:210}
+
+## Not a table
+
+    | Not a table because 4 spaces start a code block |
+| ---- |
+| Data |
+
+```Ruby
+  | Not a table becase it's a code block| Column |
+  | ---- | --- |
+  | | | | | | |
+```
+
+## Table inside heading
+
+### |This is not a table|

--- a/test/rule_tests/table_format_validation_style.rb
+++ b/test/rule_tests/table_format_validation_style.rb
@@ -1,3 +1,1 @@
-all
-exclude_rule 'MD046'
-exclude_rule 'MD009'
+tag :tables

--- a/test/rule_tests/table_format_validation_style.rb
+++ b/test/rule_tests/table_format_validation_style.rb
@@ -1,0 +1,3 @@
+all
+exclude_rule 'MD046'
+exclude_rule 'MD009'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? See [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) for tips on writing a good commit message -->
This pull request adds three new features for validation of markdown tables.  The validation rules are (as also described in the linked issue)

* MD055 - Each row must start and end with a '|'
* MD056 - Number of columns is the same for all rows
* MD057 - In the second row every column must have at least '---', possibly surrounded with alignment ':' chars

## Related Issues
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Add a link to all corresponding Github issues here, using any [appropriate keywords](https://help.github.com/en/articles/closing-issues-using-keywords) as appropriate -->
Closes #385 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/master/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `master`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
