### PR TITLE
Fix example for rulesets flag in configuration docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,7 @@ relative to the `mdlrc` and not the path the user happens to be in.
 Rulesets - Load a custom ruleset file. This option allows you to load custom
 rules in addition to those included with markdownlint.
 
-* Command line: `-u ruleset.rb,ruleset2.rb`, `--rules ruleset.rb,ruleset2.rb`
+* Command line: `-u ruleset.rb,ruleset2.rb`, `--rulesets ruleset.rb,ruleset2.rb`
 * Config file: `rulesets ['ruleset.rb', 'ruleset2.rb']`
 * Default: Don't load any additional rulesets
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? See [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) for tips on writing a good commit message -->

The configuration documentation has examples for the usage of all flags. In the example for `--rulesets` the long-form example is wrong. This was probably a copy-paste error.
This PR fixes the example.

## Related Issues
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Add a link to all corresponding GitHub issues here, using any [appropriate keywords](https://help.github.com/en/articles/closing-issues-using-keywords) as appropriate -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/main/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `main`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
