### PR TITLE
reformat repology badge, use multiple columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A tool to check markdown files and flag style issues.
 
 Markdownlint is packaged in some distributions as well as distributed via
 RubyGems. Check the list below to see if it's packaged for your distribution,
-and if so, feel free to use your distros package manager to install it.
+and if so, feel free to use your distribution's package manager to install it.
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/mdl-markdownlint.svg)](https://repology.org/project/mdl-markdownlint/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/mdl-markdownlint.svg?columns=3)](https://repology.org/project/mdl-markdownlint/versions)
 
-To install from rubygems, run:
+Else, to install from rubygems, run:
 
 ```shell
 gem install mdl


### PR DESCRIPTION
## Description

Inspired by the corresponding README of the mopac project,[1] a three column layout is less obtrusive while reading the landing page, than the previous long "waterfall like" pattern.

[1] https://github.com/openmopac/mopac/

## Related Issues
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Add a link to all corresponding GitHub issues here, using any [appropriate keywords](https://help.github.com/en/articles/closing-issues-using-keywords) as appropriate -->

Does not appear as applicable here.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation (non-breaking change that does not add functionality but updates documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/main/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `main`, if not - rebase it

- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
