### PR TITLE
New 'unreleased' in CHANGELOG; fix docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## Unreleased
+
 ## [v0.14.0] (2025-11-25)
 
 ### Fixed

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -19,8 +19,9 @@ docker run --rm -v ${PWD}:/data markdownlint/markdownlint .
 The following will tag and upload a new release. Replace X.Y.Z as appropriate.
 
 ```shell
+VERSION=X.Y.Z
 podman build -t markdownlint/markdownlint:latest \
-    -t markdownlint/markdownlint:X.Y.Z .
+    -t markdownlint/markdownlint:${VERSION?} .
 podman push markdownlint/markdownlint:latest
-podman push markdownlint/markdownling:X.Y.Z
+podman push markdownlint/markdownling:${VERSION?}
 ```


### PR DESCRIPTION
* Add `unreleased` back to CHANGELOG now that release is cut
* Cleanup docker docs

Signed-off-by: Phil Dibowitz <phil@ipom.com>
