### PR TITLE
Fix fenced code blocks not detected without preceding blank line

### DIFF
--- a/lib/mdl/kramdown_parser.rb
+++ b/lib/mdl/kramdown_parser.rb
@@ -16,6 +16,14 @@ module Kramdown
 
       # Regular kramdown parser, but with GFM style fenced code blocks
       FENCED_CODEBLOCK_MATCH = Kramdown::Parser::GFM::FENCED_CODEBLOCK_MATCH
+
+      # End paragraphs when a fenced code block starts, matching GFM
+      # behavior. Without this, fenced code blocks without a preceding
+      # blank line are swallowed into the paragraph.
+      PARAGRAPH_END = Regexp.union(
+        Kramdown::Parser::Kramdown::PARAGRAPH_END,
+        Kramdown::Parser::GFM::FENCED_CODEBLOCK_START,
+      )
     end
   end
 end


### PR DESCRIPTION
The base kramdown parser's PARAGRAPH_END regex does not include
FENCED_CODEBLOCK_START, so fenced code blocks immediately after text
(without a blank line) are swallowed into the paragraph instead of
being parsed as code blocks. This caused MD013 ignore_code_blocks
to miss those blocks.

Override PARAGRAPH_END in the custom MarkdownLint parser to include
FENCED_CODEBLOCK_START, matching the GFM parser's behavior.

Closes: #446

Signed-off-by: Phil Dibowitz <phil@ipom.com>
