### PR TITLE
Fix front matter offset when blank line follows closing ---

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -29,7 +29,7 @@ module MarkdownLint
     def initialize(text, ignore_front_matter = false)
       regex = /^---\n(.*?)---\n\n?/m
       if ignore_front_matter && regex.match(text)
-        @offset = regex.match(text).to_s.split("\n").length
+        @offset = regex.match(text).to_s.count("\n")
         text.sub!(regex, '')
       else
         @offset = 0

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -234,7 +234,7 @@ class TestCli < Minitest::Test
 
     expected = <<~OUTPUT
       #{path}/jekyll_post.md:16: MD001 Header levels should only increment by one level at a time
-      #{path}/jekyll_post_2.md:16: MD001 Header levels should only increment by one level at a time
+      #{path}/jekyll_post_2.md:17: MD001 Header levels should only increment by one level at a time
 
       Further documentation is available for these failures:
        - MD001: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md001---header-levels-should-only-increment-by-one-level-at-a-time


### PR DESCRIPTION
The offset calculation used .split("\n").length which drops trailing
empty strings, undercounting when the front matter regex consumes a
blank line after the closing ---. Use .count("\n") instead to
correctly count all consumed lines.

Closes: #496

Signed-off-by: Phil Dibowitz <phil@ipom.com>
