### PR TITLE
Fix MD029 false positive for ordered lists inside blockquotes

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -504,18 +504,16 @@ rule 'MD029', 'Ordered list item prefix' do
       doc.find_type_elements(:ol).map do |l|
         doc.find_type_elements(:li, false, l.children)
            .map.with_index do |i, idx|
-          unless doc.element_line(i).strip.start_with?("#{idx + 1}. ")
-            doc.element_linenumber(i)
-          end
+          line = doc.element_line(i).gsub(/^[\s>]+/, '')
+          doc.element_linenumber(i) unless line.start_with?("#{idx + 1}. ")
         end
       end.flatten.compact
     when :one
       doc.find_type_elements(:ol).map do |l|
         doc.find_type_elements(:li, false, l.children)
       end.flatten.map do |i|
-        unless doc.element_line(i).strip.start_with?('1. ')
-          doc.element_linenumber(i)
-        end
+        line = doc.element_line(i).gsub(/^[\s>]+/, '')
+        doc.element_linenumber(i) unless line.start_with?('1. ')
       end.compact
     end
   end

--- a/test/rule_tests/ordered_list_item_prefix.md
+++ b/test/rule_tests/ordered_list_item_prefix.md
@@ -11,3 +11,9 @@ Bad list:
 2. Do nothing. {MD029}
 3. ??? {MD029}
 4. Failed! {MD029}
+
+Good list in blockquote:
+
+> 1. Do this.
+> 1. Do that.
+> 1. Profit!


### PR DESCRIPTION
The rule used .strip to clean list item lines before checking the
prefix, but .strip only removes whitespace, not blockquote markers.
Lines like "> 1. item" would fail the start_with?("1. ") check.
Use .gsub(/^[\s>]+/, '') to strip both whitespace and blockquote
markers.

Closes: #526

Signed-off-by: Phil Dibowitz <phil@ipom.com>
