### PR TITLE
Fix MD026 false positive on emoji shortcodes in headers

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -442,7 +442,8 @@ rule 'MD026', 'Trailing punctuation in header' do
   params :punctuation => '.,;:!?'
   check do |doc|
     doc.find_type(:header).select do |h|
-      h[:raw_text].match(/[#{params[:punctuation]}]$/)
+      h[:raw_text].match(/[#{params[:punctuation]}]$/) &&
+        !h[:raw_text].match(/:[a-zA-Z0-9_+-]+:\s*$/)
     end.map do |h|
       doc.element_linenumber(h)
     end

--- a/test/rule_tests/header_trailing_punctuation.md
+++ b/test/rule_tests/header_trailing_punctuation.md
@@ -9,3 +9,7 @@
 ## Heading 5 {MD026};
 
 ## Heading 6 {MD026}?
+
+## :warning: WARNING :warning:
+
+## Heading with emoji :rocket:


### PR DESCRIPTION
Headers ending with emoji shortcodes like :warning: were flagged for
trailing punctuation because the closing colon matched the punctuation
regex. Exclude emoji shortcodes (:[a-zA-Z0-9_+-]+:) from triggering
the rule.

Closes: #527
Closes: #451

Signed-off-by: Phil Dibowitz <phil@ipom.com>
