### PR TITLE
Fix MD011 false positive on footnote references

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -193,7 +193,7 @@ rule 'MD011', 'Reversed link syntax' do
   tags :links
   aliases 'no-reversed-links'
   check do |doc|
-    doc.matching_text_element_lines(/\([^)]+\)\[[^\]]+\]/)
+    doc.matching_text_element_lines(/\([^)]+\)\[[^\]\^]+\]/)
   end
 end
 


### PR DESCRIPTION
The reversed link regex matched footnote syntax like (text)[^footnote]
because it didn't exclude ^ at the start of the bracket content.
Add ^ to the exclusion set in the bracket character class.

Closes: #132

Signed-off-by: Phil Dibowitz <phil@ipom.com>
