### PR TITLE
Fix crash on files with invalid UTF-8 byte sequences

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -47,9 +47,12 @@ module MarkdownLint
 
     def self.new_from_file(filename, ignore_front_matter = false)
       if filename == '-'
-        new($stdin.read, ignore_front_matter)
+        new($stdin.read.scrub, ignore_front_matter)
       else
-        new(File.read(filename, :encoding => 'UTF-8'), ignore_front_matter)
+        new(
+          File.read(filename, :encoding => 'UTF-8').scrub,
+          ignore_front_matter,
+        )
       end
     end
 


### PR DESCRIPTION
Files containing invalid UTF-8 bytes caused an ArgumentError in
String#split. Use String#scrub to replace invalid byte sequences
when reading files and stdin.

Closes: #502

Signed-off-by: Phil Dibowitz <phil@ipom.com>
