### PR TITLE
Fix front matter regex matching --- inside code blocks

### DIFF
--- a/lib/mdl/doc.rb
+++ b/lib/mdl/doc.rb
@@ -27,7 +27,7 @@ module MarkdownLint
     # Create a new document given a string containing the markdown source
 
     def initialize(text, ignore_front_matter = false)
-      regex = /^---\n(.*?)---\n\n?/m
+      regex = /\A---\n(.*?)---\n\n?/m
       if ignore_front_matter && regex.match(text)
         @offset = regex.match(text).to_s.count("\n")
         text.sub!(regex, '')


### PR DESCRIPTION
The front matter regex used ^ which with the /m flag matches the
start of any line, not just the start of the string. This caused
--- markers inside fenced code blocks (e.g. yaml) to be matched
as front matter when --ignore-front-matter was used, shifting all
subsequent line numbers.

Use \A to anchor to the start of the string instead.

Closes: #508

Signed-off-by: Phil Dibowitz <phil@ipom.com>
