### PR TITLE
Fix MD014 false positive on code blocks with only blank lines

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -259,8 +259,9 @@ rule 'MD014', 'Dollar signs used before commands without showing output' do
   aliases 'commands-show-output'
   check do |doc|
     doc.find_type_elements(:codeblock).select do |e|
-      !e.value.empty? &&
-        !e.value.split(/\n+/).map { |l| l.match(/^\$\s/) }.include?(nil)
+      lines = e.value.split(/\n+/)
+      !lines.empty? &&
+        !lines.map { |l| l.match(/^\$\s/) }.include?(nil)
     end.map { |e| doc.element_linenumber(e) }
   end
 end


### PR DESCRIPTION
Code blocks containing only blank lines (e.g. ```js followed by empty
lines) triggered MD014 because splitting on /\n+/ produced an empty
array, which satisfied the "all lines start with $" condition. Check
that the split result is non-empty.

Closes: #117

Signed-off-by: Phil Dibowitz <phil@ipom.com>
