### PR TITLE
Start from all rules when style only contains exclusions

### DIFF
--- a/lib/mdl/style.rb
+++ b/lib/mdl/style.rb
@@ -38,6 +38,7 @@ module MarkdownLint
 
     def exclude_rule(id)
       id = @aliases[id] if @aliases[id]
+      all if @rules.empty?
       @rules.delete(id)
     end
 
@@ -46,6 +47,7 @@ module MarkdownLint
     end
 
     def exclude_tag(tag)
+      all if @rules.empty?
       @rules.subtract(@tagged_rules[tag])
     end
 


### PR DESCRIPTION
A style file with only exclude_rule or exclude_tag calls ended up
with zero rules, because exclusions operated on an empty set.
Now exclude_rule and exclude_tag implicitly start from the full
ruleset if no rules have been added yet.

Closes: #369

Signed-off-by: Phil Dibowitz <phil@ipom.com>
