### PR TITLE
Fix MD040 false positive on tab-indented code blocks

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -755,7 +755,8 @@ rule 'MD040', 'Fenced code blocks should have a language specified' do
     # the class attribute set to language-languagename.
     doc.element_linenumbers(doc.find_type_elements(:codeblock).select do |i|
                               !i.attr['class'].to_s.start_with?('language-') &&
-                                !doc.element_line(i).start_with?('    ')
+                                !doc.element_line(i).start_with?('    ') &&
+                                !doc.element_line(i).start_with?("\t")
                             end)
   end
 end


### PR DESCRIPTION
MD040 excluded space-indented code blocks (4 spaces) but not
tab-indented ones. A hard tab at the start of a line creates an
indented code block, not a fenced one, so it should not require
a language specifier.

Closes: #397

Signed-off-by: Phil Dibowitz <phil@ipom.com>
