### PR TITLE
Fix MD034 false positive for URLs inside HTML elements

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -634,7 +634,9 @@ rule 'MD034', 'Bare URL used' do
   tags :links, :url
   aliases 'no-bare-urls'
   check do |doc|
-    errors = doc.matching_text_element_lines(%r{https?://})
+    errors = doc.matching_text_element_lines(
+      %r{https?://}, %i{a html_element}
+    )
     # Text elements inside tables lack location info, so check table
     # text elements separately using the table's location.
     doc.find_type_elements(:table).each do |t|


### PR DESCRIPTION
When markdown content is inside HTML block elements like `<details>`,
kramdown treats the content as raw text rather than parsing it as
markdown. MD034 then flags URLs in that text as "bare URLs" even
though they may be properly formatted links in the source. Exclude
text nodes nested inside html_element from MD034 matching.

Closes: #435

Signed-off-by: Phil Dibowitz <phil@ipom.com>
