### PR TITLE
Error when explicitly specified config file is not found

### DIFF
--- a/lib/mdl/cli.rb
+++ b/lib/mdl/cli.rb
@@ -122,6 +122,9 @@ module MarkdownLint
       # Only fall back to ~/.mdlrc if we are using the default value for -c
       if filename.nil? && (config[:config_file] == CONFIG_FILE)
         filename = File.expand_path("~/#{CONFIG_FILE}")
+      elsif filename.nil? && config[:config_file] != CONFIG_FILE
+        warn "Config file '#{config[:config_file]}' not found"
+        exit 3
       end
 
       if !filename.nil? && File.exist?(filename)


### PR DESCRIPTION
When the user passes --config with a path that doesn't exist,
mdl silently ignored it and ran without any config. Now it
prints an error and exits with code 3 (matching the existing
convention for file-not-found errors).

Closes: #477

Signed-off-by: Phil Dibowitz <phil@ipom.com>
