### PR TITLE
Fix double slashes in file paths when directory has trailing slash

### DIFF
--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -62,6 +62,7 @@ module MarkdownLint
 
     # Recurse into directories
     cli.cli_arguments.each_with_index do |filename, i|
+      filename = filename.chomp('/') if filename.end_with?('/')
       if Dir.exist?(filename)
         if Config[:git_recurse]
           Dir.chdir(filename) do


### PR DESCRIPTION
When a directory argument ends with /, the Dir glob produces paths
with double slashes (e.g. source/docs//file.md). Strip trailing
slashes from directory arguments before globbing.

Closes: #495

Signed-off-by: Phil Dibowitz <phil@ipom.com>
