### PR TITLE
Skip docs footer for rules without a docs URL

### DIFF
--- a/lib/mdl.rb
+++ b/lib/mdl.rb
@@ -124,10 +124,11 @@ module MarkdownLint
         # for that) then, instead of making the output ugly with long URLs, we
         # print them at the end. And of course we only want to print each URL
         # once.
-        if !Config[:json] && !Config[:sarif] &&
-           !$stdout.tty? && !docs_to_print.include?(rule)
-          docs_to_print << rule
-        end
+        next unless !Config[:json] && !Config[:sarif] &&
+                    !$stdout.tty? && rule.docs_url &&
+                    !docs_to_print.include?(rule)
+
+        docs_to_print << rule
       end
     end
 


### PR DESCRIPTION
When output is not a TTY, rules with errors get their documentation
URLs printed at the end. Rules without a docs_url (e.g. custom rules)
were still included, producing lines like "- MD999: " with no URL.
Only collect rules that actually have a docs URL.

Closes: #498

Signed-off-by: Phil Dibowitz <phil@ipom.com>
