### PR TITLE
Fix MD031 false positive on inline backtick code spans

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -568,7 +568,15 @@ rule 'MD031', 'Fenced code blocks should be surrounded by blank lines' do
         next
       end
 
-      fence = in_code ? nil : Regexp.last_match(1)
+      marker = Regexp.last_match(1)
+      # Backtick info strings cannot contain backticks (CommonMark spec),
+      # so a line like ```test``` is inline code, not a fence opener.
+      if marker[0] == '`' && !in_code
+        rest = line.strip[marker.length..]
+        next if rest&.include?('`')
+      end
+
+      fence = in_code ? nil : marker
       in_code = !in_code
       if (in_code && !lines[linenum - 1].empty?) ||
          (!in_code && !lines[linenum + 1].empty?)


### PR DESCRIPTION
A line like ```test``` (backtick code span) was treated as a fence
opener by MD031's state machine, corrupting all subsequent fence
detection. Per CommonMark spec, backtick info strings cannot contain
backticks, so skip backtick fence matches where the remainder of the
line contains additional backticks.

Closes: #524

Signed-off-by: Phil Dibowitz <phil@ipom.com>
