### PR TITLE
MD013: Detect table-like lines even when kramdown parses them as paragraphs

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -255,6 +255,17 @@ rule 'MD013', 'Line length' do
         end
       end
     end.flatten
+    # Fallback: detect table-like lines not recognized by kramdown
+    # (e.g. tables without surrounding blank lines are parsed as paragraphs)
+    unless params[:tables]
+      doc.lines.each_with_index do |line, i|
+        linenum = i + 1
+        next if table_lines.include?(linenum)
+        next if codeblock_lines.include?(linenum)
+
+        table_lines << linenum if line.match?(/^\s*\|.*\|/)
+      end
+    end
     overlines = doc.matching_lines(/^.{#{@params[:line_length]}}.+/)
     if !params[:code_blocks] || params[:ignore_code_blocks]
       overlines -= codeblock_lines

--- a/test/rule_tests/md013_ignore_long_lines_in_tables.md
+++ b/test/rule_tests/md013_ignore_long_lines_in_tables.md
@@ -1,0 +1,16 @@
+This is a short line.
+
+This is a very very very very very very very very very very very very very very very very very very very very long line. {MD013}
+
+This is a short line.
+
+| Column A | Column B | Column C | Column D | Column E | Column F | Column G | Column H | Column I |
+| -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
+| Cell A   | Cell B   | Cell C   | Cell D   | Cell E   | Cell F   | Cell G   | Cell H   | Cell I   |
+
+This line is fine.
+
+# Header
+| Column A | Column B | Column C | Column D | Column E | Column F | Column G | Column H | Column I |
+| -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
+| Cell A   | Cell B   | Cell C   | Cell D   | Cell E   | Cell F   | Cell G   | Cell H   | Cell I   |

--- a/test/rule_tests/md013_ignore_long_lines_in_tables_style.rb
+++ b/test/rule_tests/md013_ignore_long_lines_in_tables_style.rb
@@ -1,0 +1,4 @@
+all
+rule 'MD013', :tables => false
+exclude_rule 'MD022'
+exclude_rule 'MD041'


### PR DESCRIPTION
When tables lack surrounding blank lines, kramdown doesn't recognize them
as table elements, so the :tables => false parameter had no effect on those
lines. Add fallback detection for pipe-delimited lines.

Closes: #154

Signed-off-by: Phil Dibowitz <phil@ipom.com>
