### PR TITLE
Accept string values for symbol params in style files

### DIFF
--- a/lib/mdl/ruleset.rb
+++ b/lib/mdl/ruleset.rb
@@ -35,7 +35,21 @@ module MarkdownLint
     end
 
     def params(params = nil)
-      @params.update(params) unless params.nil?
+      unless params.nil?
+        # Normalize string values to symbols where the rule's default is
+        # a symbol AND the string looks like a simple identifier, so that
+        # style files can use either :atx or "atx". Values like "---"
+        # (MD035 hr style) are left as strings.
+        params = params.each_with_object({}) do |(k, v), h|
+          h[k] = if v.is_a?(String) && @params[k].is_a?(Symbol) &&
+                    v.match?(/\A[a-z][a-z_]*\z/)
+                   v.to_sym
+                 else
+                   v
+                 end
+        end
+        @params.update(params)
+      end
       @params
     end
 


### PR DESCRIPTION
Style files using string values like :style => "atx" instead of
:style => :atx caused false positives because the rule compared
symbols against strings. Auto-convert string param values to
symbols when the rule's default is a symbol and the value looks
like an identifier.

Closes: #159

Signed-off-by: Phil Dibowitz <phil@ipom.com>
