### PR TITLE
Fix MD007 false positive on unrelated lists at different indent levels

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -142,16 +142,24 @@ rule 'MD007', 'Unordered list indentation' do
   params :indent => 3
   check do |doc|
     errors = []
-    indents = doc.find_type(:ul).map do |e|
-      [doc.indent_for(doc.element_line(e)), doc.element_linenumber(e)]
-    end
-    curr_indent = indents[0][0] unless indents.empty?
-    indents.each do |indent, linenum|
-      if (indent > curr_indent) && (indent - curr_indent != @params[:indent])
-        errors << linenum
+    # Check indentation of nested ul elements relative to their parent ul.
+    # Only compare parent-child ul pairs to avoid false positives when
+    # unrelated lists appear at different indent levels.
+    def check_ul_indent(doc, elements, parent_indent, errors, indent)
+      elements.each do |e|
+        if e.type == :ul
+          el_indent = doc.indent_for(doc.element_line(e))
+          if parent_indent && (el_indent > parent_indent) &&
+             (el_indent - parent_indent != indent)
+            errors << doc.element_linenumber(e)
+          end
+          check_ul_indent(doc, e.children, el_indent, errors, indent)
+        else
+          check_ul_indent(doc, e.children, parent_indent, errors, indent)
+        end
       end
-      curr_indent = indent
     end
+    check_ul_indent(doc, doc.elements, nil, errors, @params[:indent])
     errors
   end
 end


### PR DESCRIPTION
MD007 compared indentation sequentially across all unordered lists in
the document, even when they were in completely separate contexts
(e.g. a top-level bullet list vs a nested list inside an ordered list
item). Rewrite to walk the element tree and only compare parent-child
ul pairs.

Closes: #313

Signed-off-by: Phil Dibowitz <phil@ipom.com>
