### PR TITLE
MD013: Add :headings parameter to exclude headings from line length

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -418,9 +418,7 @@ Tags: line_length
 
 Aliases: line-length
 
-Parameters: line_length, ignore_code_blocks, code_blocks, tables (number;
-default 80, boolean; default false, boolean; default true, boolean; default
-true)
+Parameters: line_length, ignore_code_blocks, code_blocks, tables, headings (number; default 80, boolean; default false, boolean; default true, boolean; default true, boolean; default true)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line
@@ -432,9 +430,9 @@ being forced to break them in the middle.
 
 You also have the option to exclude this rule for code blocks. To
 do this, set the `ignore_code_blocks` parameter to true. To exclude this rule
-for tables set the `tables` parameters to false.  Setting the parameter
-`code_blocks` to false to exclude the rule for code blocks is deprecated and
-will be removed in a future release.
+for tables set the `tables` parameter to false. To exclude this rule for
+headings set the `headings` parameter to false. Setting the parameter `code_blocks` to false to exclude the rule for
+code blocks is deprecated and will be removed in a future release.
 
 Code blocks are included in this rule by default since it is often a
 requirement for document readability, and tentatively compatible with code

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -242,7 +242,7 @@ rule 'MD013', 'Line length' do
   tags :line_length
   aliases 'line-length'
   params :line_length => 80, :ignore_code_blocks => false, :code_blocks => true,
-         :tables => true
+         :tables => true, :headings => true
 
   check do |doc|
     # Every line in the document that is part of a code block.
@@ -274,6 +274,10 @@ rule 'MD013', 'Line length' do
         table_lines << linenum if line.match?(/^\s*\|.*\|/)
       end
     end
+    # Every line in the document that is a header.
+    header_lines = doc.find_type_elements(:header).map do |e|
+      doc.element_linenumber(e)
+    end
     overlines = doc.matching_lines(/^.{#{@params[:line_length]}}.+/)
     if !params[:code_blocks] || params[:ignore_code_blocks]
       overlines -= codeblock_lines
@@ -284,6 +288,7 @@ rule 'MD013', 'Line length' do
       end
     end
     overlines -= table_lines unless params[:tables]
+    overlines -= header_lines unless params[:headings]
     overlines
   end
 end

--- a/test/rule_tests/md013_ignore_long_lines_in_headers.md
+++ b/test/rule_tests/md013_ignore_long_lines_in_headers.md
@@ -1,0 +1,9 @@
+# This is a very very very very very very very very very very very very very very very very very very long heading
+
+This is a short line.
+
+This is a very very very very very very very very very very very very very very very very very very very very long line. {MD013}
+
+This is a short line.
+
+## This is another very very very very very very very very very very very very very very very very very long heading

--- a/test/rule_tests/md013_ignore_long_lines_in_headers_style.rb
+++ b/test/rule_tests/md013_ignore_long_lines_in_headers_style.rb
@@ -1,0 +1,2 @@
+all
+rule 'MD013', :headings => false


### PR DESCRIPTION
Headers/headings had no option to be excluded from line length checking.
Add :headings parameter (default true) so users can set it to false to
skip heading lines.

Closes: #326

Signed-off-by: Phil Dibowitz <phil@ipom.com>
