### PR TITLE
MD034: Fix false positive when link text contains pipe character

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -715,7 +715,16 @@ rule 'MD034', 'Bare URL used' do
         end
       end
     end
-    errors.uniq.sort
+    # Filter out false positives where the source line doesn't actually
+    # contain a bare URL (kramdown can misparse links containing pipes
+    # as tables, reporting wrong line numbers)
+    errors.uniq.sort.select do |linenum|
+      line = doc.lines[linenum - 1]
+      next false if line.nil?
+
+      # Strip URLs inside markdown links, then check if a bare URL remains
+      line.gsub(%r{\]\(https?://[^)]*\)}, '').match?(%r{https?://})
+    end
   end
 end
 

--- a/test/rule_tests/links.md
+++ b/test/rule_tests/links.md
@@ -7,3 +7,7 @@ which will tell you all you want to know.
 http://www.google.com/ {MD034}
 
 This link should be fine: <http://www.google.com/>
+
+* [Pipe | in link text](https://example.com)
+
+* [Text | More text](https://blog.sean.taipei/2017/05/test)


### PR DESCRIPTION
When link text contains a pipe (e.g. [text | more](url)), kramdown
misparsed it as a table, causing a bare URL false positive on the wrong
line. Verify that reported error lines actually contain bare URLs on the
source line after stripping markdown link constructs.

Closes: #328

Signed-off-by: Phil Dibowitz <phil@ipom.com>
