### PR TITLE
Fix MD032 false positive on HTML comments adjacent to lists

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -645,12 +645,22 @@ rule 'MD032', 'Lists should be surrounded by blank lines' do
     # without surrounding whitespace, so examine the lines directly.
     in_list = false
     in_code = false
+    in_comment = false
     fence = nil
     prev_line = ''
     doc.lines.each_with_index do |line, linenum|
       next if line.strip == '{:toc}'
 
-      unless in_code
+      # Track HTML comments
+      if !in_comment && line.match?(/<!--/) && !line.match?(/-->/)
+        in_comment = true
+      elsif in_comment && line.match?(/-->/)
+        in_comment = false
+        prev_line = ''
+        next
+      end
+
+      unless in_code || in_comment
         list_marker = line.strip.match(/^([*+-]|(\d+\.))\s/)
         if list_marker && !in_list && !prev_line.match(/^($|\s)/)
           errors << (linenum + 1)


### PR DESCRIPTION
MD032's line-based list detection treated HTML comment lines as
regular content, triggering "lists should be surrounded by blank
lines" when comments appeared next to list items. Track multi-line
HTML comment blocks and skip list detection inside them.

Closes: #390

Signed-off-by: Phil Dibowitz <phil@ipom.com>
