### PR TITLE
Fix MD027 false positive on blockquotes with soft line breaks

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -505,7 +505,13 @@ rule 'MD027', 'Multiple spaces after blockquote symbol' do
       # element
       errors << linenum if doc.element_line(e).match(/^\s*>  /)
       lines.each do |line|
-        errors << linenum if line.start_with?(' ')
+        # Check extracted text for leading spaces, but verify against the
+        # source line to avoid false positives from kramdown text processing
+        # (e.g. em-dash conversion creating leading spaces).
+        src = doc.lines[linenum - 1]
+        if line.start_with?(' ') && src&.match?(/^\s*(?:>\s?)+\s{2,}\S/)
+          errors << linenum
+        end
         linenum += 1
       end
     end


### PR DESCRIPTION
Blockquotes containing backslash line breaks (typeset poetry) could
trigger MD027 because kramdown's text extraction introduced leading
spaces from em-dash conversion. Cross-check extracted text against
the actual source line to confirm the spaces are really in the
blockquote syntax.

Closes: #510

Signed-off-by: Phil Dibowitz <phil@ipom.com>
