### PR TITLE
Various improvements to MD013

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -418,7 +418,7 @@ Tags: line_length
 
 Aliases: line-length
 
-Parameters: line_length, ignore_code_blocks, code_blocks, tables, headings (number; default 80, boolean; default false, boolean; default true, boolean; default true, boolean; default true)
+Parameters: line_length, ignore_code_blocks, code_blocks, tables, headings, treat_links_as_single_words (number; default 80, boolean; default false, boolean; default true, boolean; default true, boolean; default true, boolean; default false)
 
 This rule is triggered when there are lines that are longer than the
 configured line length (default: 80 characters). To fix this, split the line
@@ -437,6 +437,10 @@ code blocks is deprecated and will be removed in a future release.
 Code blocks are included in this rule by default since it is often a
 requirement for document readability, and tentatively compatible with code
 rules. Still, some languages do not lend themselves to short lines.
+
+Set `treat_links_as_single_words` to true to suppress this rule for lines
+whose entire content is a markdown link (e.g. `[text](url)`), as well as list
+items whose entire content is a single word or a markdown link.
 
 ## MD014 - Dollar signs used before commands without showing output
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -242,7 +242,8 @@ rule 'MD013', 'Line length' do
   tags :line_length
   aliases 'line-length'
   params :line_length => 80, :ignore_code_blocks => false, :code_blocks => true,
-         :tables => true, :headings => true
+         :tables => true, :headings => true,
+         :treat_links_as_single_words => false
 
   check do |doc|
     # Every line in the document that is part of a code block.
@@ -274,7 +275,15 @@ rule 'MD013', 'Line length' do
         table_lines << linenum if line.match?(/^\s*\|.*\|/)
       end
     end
-    single_word_lines = doc.matching_lines(/^\S+$/)
+    single_word_lines = doc.matching_lines(/^\s*\S+$/) +
+                        doc.matching_lines(/^\s*(?:[-*+]|\d+[.)])\s+\S+$/)
+    if params[:treat_links_as_single_words]
+      link_re = /\[.*\]\([^)]*\)/
+      list_re = /^\s*(?:[-*+]|\d+[.)])\s+#{link_re.source}$/
+      single_word_lines +=
+        doc.matching_lines(/^\s*#{link_re.source}$/) +
+        doc.matching_lines(list_re)
+    end
     # Every line in the document that is a header.
     header_lines = doc.find_type_elements(:header).map do |e|
       doc.element_linenumber(e)

--- a/test/rule_tests/long_lines.md
+++ b/test/rule_tests/long_lines.md
@@ -1,3 +1,23 @@
 This is a very very very very very very very very very very very very very very long line {MD013}
 
 This line however, while very long, doesn't have whitespace after the 80th columnwhichallowsforURLsandotherlongthings. {MD013}
+
+[This is a markdown link whose text has spaces but the whole line is just the link](https://example.com/path) {MD013}
+
+* [This is a list item whose only content is a markdown link](https://example.com/very/long/path/here) {MD013}
+
+* verylongwordthatexceedsthelinelimitbecauseithasnospacesandistheentirelistitemcontent
+
+1. [This is an ordered list item whose only content is a markdown link](https://example.com/path) {MD013}
+
+1. verylongwordthatexceedsthelinelimitbecauseithasnospacesandistheentireorderedlistitem
+
+* An item with a continuation line whose content is a single long word.
+  This-is-a-very-long-word-that-does-not-fit-in-eighty-characters-and-will-trigger-lint-rule-violation
+
+* An item whose continuation is a backtick-wrapped word.
+  `a-big-long-word-herea-big-long-word-herea-big-long-word-herea-big-long-word-here`
+
+* [Package Maintenance Guide](
+  https://docs.fedoraproject.org/en-US/package-maintainers/Package_Maintenance_Guide/
+  )

--- a/test/rule_tests/md013_treat_links_as_single_words.md
+++ b/test/rule_tests/md013_treat_links_as_single_words.md
@@ -1,0 +1,17 @@
+This is a very very very very very very very very very very very very very very long line {MD013}
+
+[This is a markdown link whose text has spaces but the whole line is just the link](https://example.com/path)
+
+* [This is a list item whose only content is a markdown link](https://example.com/very/long/path/here)
+
+* verylongwordthatexceedsthelinelimitbecauseithasnospacesandistheentirelistitemcontent
+
+1. [This is an ordered list item whose only content is a markdown link](https://example.com/path)
+
+1. verylongwordthatexceedsthelinelimitbecauseithasnospacesandistheentireorderedlistitem
+
+1) [This is an ordered list with paren style whose only content is a link](https://example.com/path)
+
+1) verylongwordthatexceedsthelinelimitbecauseithasnospacesandisorderedlistwithparenstyle
+
+A line [with a very long link whose text has spaces but the whole line is just the link](https://example.com/path) {MD013}

--- a/test/rule_tests/md013_treat_links_as_single_words_style.rb
+++ b/test/rule_tests/md013_treat_links_as_single_words_style.rb
@@ -1,0 +1,3 @@
+all
+exclude_rule 'MD041'
+rule 'MD013', :treat_links_as_single_words => true


### PR DESCRIPTION
* Do not trigger on a single long word in backticks
* Do not trigger on a single long word alone on a line contuation (from a list or
  link)
* Do not trigger on a list item with a single long word
* Provide a new treat_links_as_single_word option to allow people to not
  break up links

Closes #573
Relevant to #539

Signed-off-by: Phil Dibowitz <phil@ipom.com>
