### PR TITLE
Fixed fenced code block regex to recognize multi line code blocks again

### DIFF
--- a/lib/mdl/kramdown_parser.rb
+++ b/lib/mdl/kramdown_parser.rb
@@ -21,7 +21,7 @@ module Kramdown
       # Capture groups match GFM's: 1=fence, 2=fence-char, 3=full-info,
       # 4=first-word, 5=content.
       FENCED_CODEBLOCK_MATCH =
-        /^ {0,3}(([~`]){3,})\s*?((\S+?)[^\n]*)?\n(.*?)^ {0,3}\1\2*\s*?\n/m
+        /^ {0,3}(([~`]){3,})\s*?((\S+?)[^\n]*)?\n([\S\s]*?)^ {0,3}\1\2*\s*?\n/m
 
       # End paragraphs when a fenced code block starts, matching GFM
       # behavior. Without this, fenced code blocks without a preceding


### PR DESCRIPTION
## Description
Hi, thanks for the great project.
In the recent change to the detection of fenced code blocks (commit 9d5ec38) I found an issue where the regex would not detect multi-line code blocks any more. This was most likely caused by the `(.*?)` regex construct, which captured the code block's content, yet dots do not recognize newlines. This caused the mis-detection of multi-line code blocks and consequently, a lot of newly flagged issues in the markdown of my docs repo.

This PR proposes the `([\S\s]*?)` construct instead, which does capture newlines.

To see the issue in action: [example with dot](https://regex101.com/?regex=%5E+%7B0%2C3%7D%28%28%5B%7E%60%5D%29%7B3%2C%7D%29%5Cs*%3F%28%28%5CS%2B%3F%29%5B%5E%5Cn%5D*%29%3F%5Cn%28.*%3F%29%5E+%7B0%2C3%7D%5C1%5C2*%5Cs*%3F%5Cn&testString=%60%60%60c+hlines%3D2%0A%23include+%3Cstdio.h%3E%0A%0Aint+main%28%29+%7B+return+0%3B+%7D%0A%60%60%60%0A&flags=m&flavor=pcre2&delimiter=%2F) and [example with \S\s](https://regex101.com/?regex=%5E+%7B0%2C3%7D%28%28%5B%7E%60%5D%29%7B3%2C%7D%29%5Cs*%3F%28%28%5CS%2B%3F%29%5B%5E%5Cn%5D*%29%3F%5Cn%28%5B%5CS%5Cs%5D*%3F%29%5E+%7B0%2C3%7D%5C1%5C2*%5Cs*%3F%5Cn&testString=%60%60%60c+hlines%3D2%0A%23include+%3Cstdio.h%3E%0A%0Aint+main%28%29+%7B+return+0%3B+%7D%0A%60%60%60%0A&flags=m&flavor=pcre2&delimiter=%2F)

## Related Issues
PR #590 introduced the new regex to find fenced code blocks, to fix #176

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/main/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `main`, if not - rebase it
- [ ] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
