### PR TITLE
Fixed nil exception within MD024 with allow_different_nesting

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -493,7 +493,7 @@ rule 'MD024', 'Multiple headers with the same content' do
           stack.pop
         elsif current_level < level
           stack.push([text])
-        elsif stack.last.include?(text)
+        elsif stack.last && stack.last.include?(text)
           same_nesting_duplicates.add(header)
         end
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -493,7 +493,7 @@ rule 'MD024', 'Multiple headers with the same content' do
           stack.pop
         elsif current_level < level
           stack.push([text])
-        elsif stack.last && stack.last.include?(text)
+        elsif stack&.last&.include?(text)
           same_nesting_duplicates.add(header)
         end
 

--- a/test/rule_tests/header_duplicate_content_different_nesting.md
+++ b/test/rule_tests/header_duplicate_content_different_nesting.md
@@ -1,3 +1,13 @@
+##### A Out-of-order deep header
+at the start of the file, followed by
+
+## Higher headers
+later on
+
+## Triggers a nil exception
+
+
+
 # Change log
 
 ## 2.0.0
@@ -9,3 +19,4 @@
 ## 1.0.0
 
 ### Bug fixes
+

--- a/test/rule_tests/header_duplicate_content_different_nesting.md
+++ b/test/rule_tests/header_duplicate_content_different_nesting.md
@@ -19,4 +19,3 @@ later on
 ## 1.0.0
 
 ### Bug fixes
-

--- a/test/rule_tests/header_duplicate_content_different_nesting.md
+++ b/test/rule_tests/header_duplicate_content_different_nesting.md
@@ -19,3 +19,4 @@ later on
 ## 1.0.0
 
 ### Bug fixes
+


### PR DESCRIPTION
## Description
In MD024, with allow_different_nesting set, when a file starts with a higher-level header (e.g. h5) and then drops down to lower header (e.g. h2), a "NoMethodError: undefined method 'include?' for nil" on stack.last is triggered.

I have added a small check to stack.last to prevent that. I have also added this as a test case to test/rule_tests/header_duplicate_content_different_nesting.md

## Related Issues
Didn't find any.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/main/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `main`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
