### PR TITLE
Proposal for option "allow_quoted" on rule MD034 (Bare URLs)

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1044,6 +1044,8 @@ Tags: links, url
 
 Aliases: no-bare-urls
 
+Parameters: allow_quoted (boolean, default `false`)
+
 This rule is triggered whenever a URL is given that isn't surrounded by angle
 brackets:
 
@@ -1066,6 +1068,20 @@ converted:
 
 ```markdown
 `http://www.example.com`
+```
+
+Alternatively, when setting `allow_quoted` to true, this rule also does not
+trigger on URLs that are directly enquoted in either single or double quotes.
+
+```markdown
+"http://www.example.com"
+```
+
+This is particularly helpful when using bare urls as parameters, for example
+in inline HTML or inside HUGO style shortcodes. For example:
+
+```markdown
+{{< figure src="http://www.example.com/image.png" >}}
 ```
 
 ## MD035 - Horizontal rule style

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -784,17 +784,18 @@ rule 'MD034', 'Bare URL used' do
       line = doc.lines[linenum - 1]
       next false if line.nil?
 
+      # Strip URLs inside markdown links, then check if a bare URL remains
+      line = line.gsub(%r{\]\(https?://[^)]*\)}, '')
+
       if params[:allow_quoted]
         # If allow_quoted is set, also strip any URL directly en-quoted,
         # check if a bare url remains
-        line.gsub(%r{\]\(https?://[^)]*\)}, '')
-            .gsub(%r{["]https?://\S*?["]}, '')
-            .gsub(%r{[']https?://\S*?[']}, '')
-            .match?(%r{https?://})
-      else
-        # Strip URLs inside markdown links, then check if a bare URL remains
-        line.gsub(%r{\]\(https?://[^)]*\)}, '').match?(%r{https?://})
+        line = line
+               .gsub(%r{"https?://\S*?"}, '')
+               .gsub(%r{'https?://\S*?'}, '')
       end
+
+      line.match?(%r{https?://})
     end
   end
 end

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -751,6 +751,7 @@ end
 rule 'MD034', 'Bare URL used' do
   tags :links, :url
   aliases 'no-bare-urls'
+  params :allow_quoted => false
   check do |doc|
     errors = doc.matching_text_element_lines(
       %r{https?://}, %i{a html_element}
@@ -783,8 +784,17 @@ rule 'MD034', 'Bare URL used' do
       line = doc.lines[linenum - 1]
       next false if line.nil?
 
-      # Strip URLs inside markdown links, then check if a bare URL remains
-      line.gsub(%r{\]\(https?://[^)]*\)}, '').match?(%r{https?://})
+      if params[:allow_quoted]
+        # If allow_quoted is set, also strip any URL directly en-quoted,
+        # check if a bare url remains
+        line.gsub(%r{\]\(https?://[^)]*\)}, '')
+            .gsub(%r{["]https?://\S*?["]}, '')
+            .gsub(%r{[']https?://\S*?[']}, '')
+            .match?(%r{https?://})
+      else
+        # Strip URLs inside markdown links, then check if a bare URL remains
+        line.gsub(%r{\]\(https?://[^)]*\)}, '').match?(%r{https?://})
+      end
     end
   end
 end

--- a/test/rule_tests/quoted_bare_urls.md
+++ b/test/rule_tests/quoted_bare_urls.md
@@ -1,0 +1,12 @@
+# A testset of bare urls
+
+https://www.google.com {MD034}
+
+'https://www.github.com'
+"https://www.github.com"
+{{< figure src="https://www.github.com/favicon.ico" >}}
+{{< figure src='https://www.github.com/favicon.ico' >}}
+
+{{< figure src='https://www.github.com/favicon.ico" >}} {MD034}
+{{< figure src="https://www.github.com/favicon.ico' >}} {MD034}
+

--- a/test/rule_tests/quoted_bare_urls.md
+++ b/test/rule_tests/quoted_bare_urls.md
@@ -9,4 +9,3 @@ https://www.google.com {MD034}
 
 {{< figure src='https://www.github.com/favicon.ico" >}} {MD034}
 {{< figure src="https://www.github.com/favicon.ico' >}} {MD034}
-

--- a/test/rule_tests/quoted_bare_urls_style.rb
+++ b/test/rule_tests/quoted_bare_urls_style.rb
@@ -1,0 +1,1 @@
+rule 'MD034', :allow_quoted => true


### PR DESCRIPTION
## Description
This PR proposes the new parameter "allow_quoted" in rule MD034 (Bare URLs).
With this parameter set to true (default false), the rule also does not trigger on Bare URLs that are directly enquoted in either single or double quotes. This is particularly helpful inside parameters for HTML tags or HUGO [shortcodes](https://gohugo.io/content-management/shortcodes/), where the URL is a parameter that will be processed later down the line.

We use [HUGO](https://gohugo.io/) to build our documentation page, and are using markdownlint to validate the markdown before it gets processed by Hugo. This works surprisingly well, despite the custom "shortcodes" that Hugo introduces into plain markdown to generate more complex HTML concepts. So far, the only sticky issue is that one cannot use URLs as shortcode parameters because rule MD034 then triggers. This PR intents on fixing this.

Please let me know what you think of it.

## Related Issues
Didn't find any.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/main/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `main`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
