### PR TITLE
MD013: allow link references to pass through the line length rule

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -1,3 +1,7 @@
+require 'uri'
+
+URI_REGEXP = URI::RFC2396_PARSER.make_regexp
+
 docs do |id, description|
   url_hash = [id.downcase,
               description.downcase.gsub(/[^a-z]+/, '-')].join('---')
@@ -295,7 +299,17 @@ rule 'MD013', 'Line length' do
     header_lines = doc.find_type_elements(:header).map do |e|
       doc.element_linenumber(e)
     end
+    # Every line that is a link reference:
+    #
+    # This link is referenced[1] at the bottom
+    #
+    # [1]: https://example.com
+    link_reference_lines = doc.matching_lines(/^\[.*\]: #{URI_REGEXP}$/)
+
     overlines = doc.matching_lines(/^.{#{@params[:line_length]}}.+/)
+
+    overlines -= link_reference_lines if params[:treat_links_as_single_words]
+
     overlines -= single_word_lines
     if !params[:code_blocks] || params[:ignore_code_blocks]
       overlines -= codeblock_lines

--- a/mdl.gemspec
+++ b/mdl.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-cli'
   spec.add_dependency 'mixlib-config'
   spec.add_dependency 'mixlib-shellout'
+  spec.add_dependency 'uri'
 end

--- a/test/rule_tests/md013_treat_links_as_single_words.md
+++ b/test/rule_tests/md013_treat_links_as_single_words.md
@@ -15,3 +15,5 @@ This is a very very very very very very very very very very very very very very 
 1) verylongwordthatexceedsthelinelimitbecauseithasnospacesandisorderedlistwithparenstyle
 
 A line [with a very long link whose text has spaces but the whole line is just the link](https://example.com/path) {MD013}
+
+[link ref]: https://github.com/markdownlint/markdownlint/issues/595#issue-4656984122


### PR DESCRIPTION
## Description
Markdown provides an alternate way to format links:

```md
This [link][1] will be automatically resolved, and this other [link][named-anchor] too.

[1]: https://example.com
[named-anchor]: https://example.com
```

URLs inevitably tend to be very long, but MDL wasn't monitoring for `[something]: <url>` patterns.

## Related Issues
https://github.com/markdownlint/markdownlint/issues/595

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/main/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `main`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
