### PR TITLE
Fix unittests in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,13 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      all-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Run rubocop
       run: bundle exec rubocop
     - name: Run tests
-      run: bundle exec rake
+      run: bundle exec rake test
   linelint:
     runs-on: ubuntu-latest
     name: Check if all files end in newline

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Bundler/Ruby
 vendor/
 .bundle
-Gemfile.lock
 spec/reports
 tmp
 *.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,88 @@
+PATH
+  remote: .
+  specs:
+    mdl (0.17.0)
+      kramdown (~> 2.5)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli
+      mixlib-config
+      mixlib-shellout
+
+GEM
+  remote: https://gem.coop/
+  specs:
+    ast (2.4.3)
+    base64 (0.3.0)
+    chef-utils (19.3.15)
+      concurrent-ruby
+    coderay (1.1.3)
+    concurrent-ruby (1.3.7)
+    drb (2.2.3)
+    io-console (0.8.2)
+    json (2.20.0)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
+      tomlrb
+    mixlib-shellout (3.4.10)
+      chef-utils
+    parallel (2.1.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    pry (0.16.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      reline (>= 0.6.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.4.2)
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    tomlrb (2.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  base64
+  bundler (>= 1.12, < 5)
+  mdl!
+  minitest (~> 6.0)
+  pry (~> 0.16.0)
+  rake (~> 13.3, >= 13.3.1)
+  rubocop (~> 1.81)
+
+BUNDLED WITH
+   2.6.6

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -722,8 +722,8 @@ rule 'MD032', 'Lists should be surrounded by blank lines' do
       end
       line.strip.match(/^(`{3,}|~{3,})/)
       if Regexp.last_match(1) && (
-          !in_code || (Regexp.last_match(1).slice(0, fence.length) == fence)
-        )
+        !in_code || (Regexp.last_match(1).slice(0, fence.length) == fence)
+      )
         fence = in_code ? nil : Regexp.last_match(1)
         in_code = !in_code
         in_list = false


### PR DESCRIPTION
* CI should run the unittests properly
* We should have a Gemfile.lock so that local and remote lint is the
  same
* Fix lint
* Update dependabot to group bundler updates since we're going to get
  a lot of bumps after this

Signed-off-by: Phil Dibowitz <phil@ipom.com>
