### PR TITLE
Fix default ruleset loading with older uri versions

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -1,6 +1,11 @@
 require 'uri'
 
-URI_REGEXP = URI::RFC2396_PARSER.make_regexp
+uri_parser = if URI.const_defined?(:RFC2396_PARSER, false)
+               URI::RFC2396_PARSER
+             else
+               URI::DEFAULT_PARSER
+             end
+URI_REGEXP = uri_parser.make_regexp
 
 docs do |id, description|
   url_hash = [id.downcase,

--- a/test/test_rules.rb
+++ b/test/test_rules.rb
@@ -1,6 +1,46 @@
 require_relative 'setup_tests'
+require 'open3'
+require 'rbconfig'
 
 class TestRules < Minitest::Test
+  def test_default_ruleset_loads_without_rfc2396_parser
+    libdir = File.expand_path('../lib', __dir__)
+    # Simulate the relevant legacy API using the real RFC2396 parser.
+    script = <<~'RUBY'
+      require 'uri'
+      if URI.const_defined?(:RFC2396_PARSER, false)
+        URI.send(:remove_const, :RFC2396_PARSER)
+      end
+      URI.send(:remove_const, :DEFAULT_PARSER)
+      URI.const_set(:DEFAULT_PARSER, URI::RFC2396_Parser.new)
+
+      require 'mdl/ruleset'
+      ruleset = MarkdownLint::RuleSet.new
+      ruleset.load_default
+      regexp = ruleset.singleton_class.const_get(:URI_REGEXP)
+      link_reference = /^\[.*\]: #{regexp}$/
+
+      raise 'valid link reference did not match' unless
+        link_reference.match?('[1]: https://example.com/a?b=c#d')
+      raise 'invalid link reference matched' if
+        link_reference.match?('[1]: not a url')
+    RUBY
+    env = {
+      'BUNDLE_GEMFILE' => nil,
+      'RUBYLIB' => nil,
+      'RUBYOPT' => nil,
+    }
+    _stdout, stderr, status = Open3.capture3(
+      env,
+      RbConfig.ruby,
+      "-I#{libdir}",
+      '-e',
+      script,
+    )
+
+    assert_predicate status, :success?, stderr
+  end
+
   def get_expected_errors(lines)
     # Looks for lines tagged with {MD123} to signify that a rule is expected to
     # fire for this line. It also looks for lines tagged with {MD123:1} to


### PR DESCRIPTION
`mdl` 0.18.0 crashes while loading its default ruleset with older `uri` releases, including 0.12.2 and 0.13.0, because `URI::RFC2396_PARSER` is not defined. This affects environments using the versions bundled with early Ruby 3.2 and 3.3 releases and prevents linting from starting.

Prefer `URI::RFC2396_PARSER` when available and fall back to `URI::DEFAULT_PARSER` on versions that predate it. Both paths provide the same RFC2396 regular expression, preserving the existing MD013 link-reference behavior.

The feature check is intentional because the constant's availability is not monotonic by version: `uri` 0.12.3 defines it, but 0.13.0 doesn't. On every release where it is absent, `URI::DEFAULT_PARSER` is still an RFC2396 parser. In `uri` 1.x, where the default becomes the RFC3986 parser, `URI::RFC2396_PARSER` is available and selected.
This avoids the default parser's obsolete `make_regexp` method, which warns under verbose mode and delegates to `URI::RFC2396_PARSER`.

Add an isolated subprocess regression test that simulates the relevant legacy API with the real RFC2396 parser. It loads the default ruleset with `URI::RFC2396_PARSER` unavailable, then checks that a valid link reference matches and an invalid one doesn't.

The tracked lockfile pins `uri` 1.1.1, while a plain `gem install mdl` can reuse an older bundled/default `uri`. This is the installation path used by [OpenSSL's documentation CI](https://github.com/openssl/openssl/blob/master/.github/workflows/ci-doc-changes.yml#L33-L36).
The subprocess test covers that otherwise-unrepresented API surface.

Verification was performed with Ruby 3.2.3 using both `uri` 0.12.2 and 1.1.1; the full test suite passed without failures or errors. Ruleset loading was also checked with `uri` 0.11.3, 0.12.0, 0.12.3, 0.13.0, 0.13.1, and 1.0.0. RuboCop, `ruby -c`, and `git diff --check` also passed.

## Related Issues

Fixes #605

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (non-breaking change that does not add functionality but updates documentation)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/markdownlint/markdownlint/blob/main/CONTRIBUTING.md) document.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/)
- [x] Feature branch is up-to-date with `main`, if not - rebase it
- [x] Added tests for all new/changed functionality, including tests for positive and negative scenarios
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences
